### PR TITLE
A few fixes to HI cleaning with a SoFiA clean mask

### DIFF
--- a/meerkathi/default-config.yml
+++ b/meerkathi/default-config.yml
@@ -11,8 +11,8 @@ general:
 
 
 get_data:
-  dataid: []                               
   enable: true
+  dataid: []                               
   order: 0
   meerkat_query_available:                              
     enable: true
@@ -26,9 +26,9 @@ get_data:
     description_matches: '.*'
     required_fields: [] 
   download:                       
+    enable: true
     download_mode: meerkat         
     data_url: ""    
-    enable: true
     reset: false     
   h5toms:             
     enable: true


### PR DESCRIPTION
Fixes a bug in https://github.com/ska-sa/meerkathi/pull/217

The pipeline fails at the HI imaging step if a user does not execute the 2nd WSClean run (e.g., because they are happy with the HI cube made with WSClean automask and therefore do not want to re-run WSClean with a SoFiA clean mask). In this case the subsequent steps of converting the cube's spectral axis from frequency to velocity and of source finding with SoFiA fail because the input cube names are assumed to be those of the 2nd WSClean run, and those files do not exist.

The solution implemented here consists of giving the same output file name for both WSClean runs. The reason is that if one wants to re-run WSClean with a SoFiA clean mask they are most likely not interested in the WSClean output with automask. (If they are, they can always run WSClean with automask first, save the output files elsewhere, and then run WSClean with a SoFiA mask).

Includes a few additional small changes.