### PR TITLE
Continuum clean model subtraction in HI worker

### DIFF
--- a/meerkathi/default-config.yml
+++ b/meerkathi/default-config.yml
@@ -293,7 +293,7 @@ self_cal:
   img_column: CORRECTED_DATA 
   img_pol: I
   # Calibration settings
-  cal_Gsols: []
+  cal_Gsols: [1,0]
   cal_DDsols: []
   cal_gain_amplitude_clip_low: 0.5 
   cal_gain_amplitude_clip_high: 1.5
@@ -369,6 +369,8 @@ image_HI:
   cell: 7
   weight: 'briggs'
   robust: 0
+  subtractmodelcol:
+    enable: false
   uvcontsub: 
     enable: true
     fitorder: 1

--- a/meerkathi/schema/image_HI_schema-0.1.0.yml
+++ b/meerkathi/schema/image_HI_schema-0.1.0.yml
@@ -42,6 +42,14 @@ mapping:
         desc: Default robust parameter in case of Briggs weighting. Default is 2.
         type: float
         required: false
+      subtractmodelcol:
+        desc: Replace the column CORRECTED_DATA with the difference CORRECTED_DATA - MODEL_DATA. This is useful for continuum subtraction as it enables the subtraction of the most recent continuum clean model.
+        type: map
+        mapping:
+          enable:
+            desc: Execute segment subtractmodelcol. Default is False.
+            type: bool
+            required: false
       uvcontsub:
         desc: Perform a continuum subtraction on the visibilities by fitting a fitorderth-order polynomial to xx and yy correlations at each time step.
         type: map


### PR DESCRIPTION
This is useful if no continuum model was subtracted during by the selfcal worker and the user wants to subtract the latest set of continuum clean components.

Additional minor change in selfcal worker defaults (see https://github.com/ska-sa/meerkathi/issues/167) and small fix in nr of channels returned by the Doppler correction module.