### PR TITLE
Fixes bug that prevented common bary freq grid

### DIFF
--- a/meerkathi/workers/image_HI_worker.py
+++ b/meerkathi/workers/image_HI_worker.py
@@ -89,6 +89,8 @@ def worker(pipeline, recipe, config):
                    firstchanfreq_dopp[i], chanw_dopp[i], lastchanfreq_dopp[i] = firstchanfreq_dopp[i]*corr, chanw_dopp[i]*corr, lastchanfreq_dopp[i]*corr  #Hz, Hz, Hz
     # WARNING: the following line assumes a single SPW for the HI line data being processed by this worker!
     comfreq0,comfreql,comchanw = np.max(firstchanfreq_dopp), np.min(lastchanfreq_dopp), np.max(chanw_dopp)
+    comfreq0+=comchanw # safety measure to avoid wrong Doppler settings due to change of Doppler correction during a day
+    comfreql-=comchanw # safety measure to avoid wrong Doppler settings due to change of Doppler correction during a day
     nchan_dopp=int(np.floor(((comfreql - comfreq0)/comchanw)))+1
     meerkathi.log.info('Found common barycentric frequency grid for all input .MS: {0:d} channels starting at {1:.3f} Hz and with channel width {2:.3f} Hz.'.format(nchan_dopp,comfreq0,comchanw))
 


### PR DESCRIPTION
Before imaging multiple .MS's in HI the pipeline regrids them all to a common barycentric frequency grid. Strictly, the common grid should be calculated as the maximum range of barycentric frequencies available to all MS's and for all time intervals; and with the poorest frequency resolution, i.e., the maximum Doppler-corrected channel width.

However, for the sake of speed the common barycentric frequency grid is calculated based on the Doppler corrections at midnight of the days when the data were taken for the various MS's.

This was causing issues when, during an observation, the proper barycentric frequency grid deviated significantly from the common grid. The result was that, behind the scene, CASA/mstransform would use a slightly different grid than requested for some MS's. The resulting frequency mismatch between MS's would drive WSClean crazy and result in non-sensical HI cubes.

This commit implements a (temporary?) fix to this problem. It consists in leaving the calculation of the common barycentric frequency grid as is, but then discard first and last channels to avoid the above issue. As long as the channel width is of 1 km/s or more (the maximum variation of the Doppler correction during 12 h) this will work.

In the long run we may consider calculating the common barycentric grid in a more accurate way by considering all relevant time intervals and not only the one at midnight of the day of observation of the various .MS's.