### PR TITLE
Add possibility to have lists shorter than no. iterations for extract_…

### DIFF
--- a/meerkathi/workers/self_cal_worker.py
+++ b/meerkathi/workers/self_cal_worker.py
@@ -201,8 +201,8 @@ def worker(pipeline, recipe, config):
             recipe.add('cab/pybdsm', step,
                 {
                     "image"         : im,
-                    "thresh_pix"    : config[key].get('thresh_pix', thresh_pix)[num-1 if len(config[key].get('thres_pix')) >= num else -1],
-                    "thresh_isl"    : config[key].get('thresh_isl', thresh_isl)[num-1 if len(config[key].get('thres_isl')) >= num else -1],
+                    "thresh_pix"    : config[key].get('thresh_pix', thresh_pix)[num-1 if len(config[key].get('thresh_pix')) >= num else -1],
+                    "thresh_isl"    : config[key].get('thresh_isl', thresh_isl)[num-1 if len(config[key].get('thresh_isl')) >= num else -1],
                     "outfile"       : '{:s}.fits:output'.format(calmodel),
                     "blank_limit"   : sdm.dismissable(blank_limit),
                     "adaptive_rms_box" : True,


### PR DESCRIPTION
Adds possibility to have lists shorter than number of iterations for `extract_sources:thres_pix, thres_isl` and `calibrate:output_data` in the self_calibration.

There are also several instances in self_cal_worker.py where the `calibrate:model` list does not allow for a list that is shorter than the amount of iterations however I left those as I think we do want to have the model used explicitly defined. 