### PR TITLE
Fixes #289

### DIFF
--- a/meerkathi/workers/self_cal_worker.py
+++ b/meerkathi/workers/self_cal_worker.py
@@ -498,10 +498,10 @@ def worker(pipeline, recipe, config):
                                                  prefix, num if num <= len(config['calibrate'].get('model', num))
                                                  else len(config['calibrate'].get('model', num)),
                                                  '-combined' if len(model.split('+')) >= 2 else ''),
-                    "residual-image"       : '{0:s}_{1:d}-MFS-residual.fits:output'.format(
-                                                 prefix, num),
-                    "normality-model"      :  config[step].get(
-                                                  'normality_model', 'normaltest'),
+                    "residual-image"       : '{0:s}_{1:d}{2:s}-residual.fits:output'.format(
+                                                 prefix, num, mfsprefix),
+                    "normality-model"      : config[step].get(
+                                                 'normality_model', 'normaltest'),
                     "area-factor"          : config[step].get('area_factor', 10),
                     "label"                : "meerkathi_{}".format(num),
                 },


### PR DESCRIPTION
Therefore ensure that image quality assessment is performed on the .image.fits instead of the image-MFS.fit in that case (Useful for small bandwidth data).