### PR TITLE
Vis only dr

### DIFF
--- a/meerkathi/workers/self_cal_worker.py
+++ b/meerkathi/workers/self_cal_worker.py
@@ -605,7 +605,8 @@ def worker(pipeline, recipe, config):
                 # Unlike the other ratios DR should grow hence n-1/n < 1.
 
                 if not extractsourcesset:
-                    drratio=residual0['meerkathi_{0}-restored'.format(n - 1)]['DR']/residual1['meerkathi_{0}-restored'.format(n)]['DR']
+                    drratio=fidelity_data['meerkathi_{0}-restored'.format(n - 1)]['DR']/fidelity_data[
+                                          'meerkathi_{0}-restored'.format(n)]['DR']
                 else:
                     drratio=residual0['meerkathi_{0}-model'.format(n - 1)]['DR']/residual1['meerkathi_{0}-model'.format(n)]['DR']
 


### PR DESCRIPTION
This is where `aimfast` uses the `restore-image` to compute the dynamic range.
@PeterKamphuis I based this PR on Holistic_Selfcal_Stopping.