### PR TITLE
Added mstransform:outchangrid for manual Doppler corr settings

### DIFF
--- a/meerkathi/dispatch_crew/caltables.py
+++ b/meerkathi/dispatch_crew/caltables.py
@@ -22,6 +22,6 @@ def calibrator_database():
     meerkathi.log.info("Obtaining divine knowledge from: %s" % __DB_FILENAME)
 
     __CALIBRATOR_DB = cp.catalog_parser(__DB_FILENAME)
-    meerkathi.log.info("\n" + str(__CALIBRATOR_DB))
+    #meerkathi.log.info("\n" + str(__CALIBRATOR_DB))
     return __CALIBRATOR_DB
 

--- a/meerkathi/schema/image_HI_schema-0.1.0.yml
+++ b/meerkathi/schema/image_HI_schema-0.1.0.yml
@@ -70,16 +70,16 @@ mapping:
             desc: Regridding mode (channel/velocity/frequency/channel_b). Default is 'frequency'
             type: str
             required: false
-          nchan:
-            desc: Number of channels to regrid, 'all' is for all channels or an integer number. Default is 'all'
-            type: text
-            required: false
           outframe:
             desc: Output reference frame, options 'LSRK', 'LSRD', 'BARY', 'GALACTO', 'LGROUP', 'CMB', 'GEO', 'TOPO'. Defaut is 'BARY'
             type: str
             required: false
           veltype:
             desc: Definition of velocity (as used in mode), radio or optical.  Default is 'radio'
+            type: str
+            required: false
+          outchangrid:
+            desc: Output channel grid for Doppler correction. Default is 'auto', and the pipeline will calculate the appropriate channel grid. If not 'auto' it must be in the format 'nchan,chan0,chanw' where nchan is an integer, and chan0 and chanw must include units appropriate for the chosen mode (see parameter 'mode' above)
             type: str
             required: false
           uvlin:

--- a/meerkathi/workers/split_target_worker.py
+++ b/meerkathi/workers/split_target_worker.py
@@ -50,8 +50,8 @@ def worker(pipeline, recipe, config):
 
         if pipeline.enable_task(config, 'changecentre'):
             if config['changecentre'].get('ra','') == '' or config['changecentre'].get('dec','') == '':
-                meerkathi.log.info('Wrong format for RA and/or Dec you want to change to. Check your settings of split_target:changecentre:ra and split_target:changecentre:dec')
-                meerkathi.log.info('Current settings for ra,dec are {0:s},{1:s}'.format(config['changecentre'].get('ra',''),config['changecentre'].get('dec','')))
+                meerkathi.log.error('Wrong format for RA and/or Dec you want to change to. Check your settings of split_target:changecentre:ra and split_target:changecentre:dec')
+                meerkathi.log.error('Current settings for ra,dec are {0:s},{1:s}'.format(config['changecentre'].get('ra',''),config['changecentre'].get('dec','')))
                 sys.exit(1)
             step = 'changecentre_{:d}'.format(i)
             recipe.add('cab/casa_fixvis', step,


### PR DESCRIPTION
Already for a while MeerKATHI has been able to calculate the output channel grid to be used when Doppler correcting. That's good but can lead to different channel grids for cubes that should later be mosaicked. Montage does not like that -- cubes on different channel grids cannot be mosaicked easily.

So I've now introduced the option to set the output channel grid manually at the config file. This is done with the new **optional** parameter mstransform:outchangrid .

The default value of this new parameter is "auto", in which case MeerKATHI works as it used to.

Alternatively, users can set this parameter to the string 'nchan,chan0,chanw', where: nchan is the integer number of output channels; chan0 and chanw are first channel and channel width of the grid, respectively, and should include units.