### PR TITLE
added OTFcal

### DIFF
--- a/meerkathi/default-config.yml
+++ b/meerkathi/default-config.yml
@@ -279,16 +279,32 @@
 - split_target:
     enable: true
     order: 60
-    label: corr
+    label_in: ''
+    label_out: corr
     split_target:
       enable: true
       time_average: ''
       freq_average: 1
-    hires_split:
-      enable: true
-      hires_label: hires
-      hires_spwid: 0
-      hires_spw: 'null'
+      spw: ''
+      otfcal:
+        enable: true
+        callabel: 1gc1
+        apply_delay_cal:
+          enable: true
+          field:
+           - bpcal
+        apply_bp_cal:
+          enable: true
+          field:
+           - bpcal
+        apply_gain_cal_gain:
+          enable: false
+          field:
+           - gcal
+        apply_transfer_fluxscale:
+          enable: true
+          field:
+           - gcal
     prepms:
       enable: false
     changecentre:
@@ -299,6 +315,7 @@
       enable: true
       listobs: true
       summary_json: true
+
 
 - masking:
     enable: false

--- a/meerkathi/schema/split_target_schema-0.1.0.yml
+++ b/meerkathi/schema/split_target_schema-0.1.0.yml
@@ -54,71 +54,69 @@ mapping:
             type: str
             required: false
 
-      otfcal:
-        desc: Apply OTF calibration
-        type: map
-        mapping:
-          enable:
-            desc: Execute this section
-            type: bool
-            required: true
-          callabel:
-            desc: Label of calibration tables to be used
-            type: str
-            required: true
+          otfcal:
+            desc: Apply OTF calibration
+            type: map
+            mapping:
+              enable:
+                desc: Execute this section
+                type: bool
+                required: true
+              callabel:
+                desc: Label of calibration tables to be used
+                type: str
+                required: true
 
-      apply_delay_cal:
-        type: map
-        desc: Apply the delay correction calibration table to specified fields via the CASA applycal task.
-        mapping: 
-          enable: 
-            desc: Executes application of delay correction calibration table.
-            type: bool
-            required: true
-          field: 
-            seq: 
-             - type: str 
-            desc: Field to select in the delay correction calibration table. Specify either the field number, name or as corrsponding to field spec in observation config, e.g. 'bpcal'.
-            required: true
-                           
-      apply_bp_cal:
-        type: map
-        desc: Apply the bandpass table to specified fields via the CASA applycal task.
-        mapping:
-          enable:
-            type: bool
-            desc: Executes application of bandpass table.
-            required: true
-          field:
-            seq: 
-             - type: str 
-            desc: Field to select in the bandpass table. Specify either the field number, name or as corrsponding to field spec in observation config, e.g. 'bpcal'.
+              apply_delay_cal:
+                type: map
+                desc: Apply the delay correction calibration table to specified fields via the CASA applycal task.
+                mapping: 
+                  enable: 
+                    desc: Executes application of delay correction calibration table.
+                    type: bool
+                    required: true
+                  field: 
+                    seq: 
+                      - type: str 
+                    desc: Field to select in the delay correction calibration table. Specify either the field number, name or as corrsponding to field spec in observation config, e.g. 'bpcal'.             
+              apply_bp_cal:
+                type: map
+                desc: Apply the bandpass table to specified fields via the CASA applycal task.
+                mapping:
+                  enable:
+                    type: bool
+                    desc: Executes application of bandpass table.
+                    required: true
+                  field:
+                    seq: 
+                      - type: str 
+                    desc: Field to select in the bandpass table. Specify either the field number, name or as corrsponding to field spec in observation config, e.g. 'bpcal'.
 
-      apply_gain_cal_gain:    
-        type: map
-        desc: Apply the gain calibration table to specified fields via the CASA applycal task.
-        mapping:
-           enable:
-             type: bool
-             desc: Executes application of gain calibration table.
-             required: true
-           field:
-             seq: 
-              - type: str 
-             desc: Field to select in the gain calibration table. Specify either the field number, name or as corrsponding to field spec in observation config, e.g. 'gcal'.
+              apply_gain_cal_gain:    
+                type: map
+                desc: Apply the gain calibration table to specified fields via the CASA applycal task.
+                mapping:
+                  enable:
+                    type: bool
+                    desc: Executes application of gain calibration table.
+                    required: true
+                  field:
+                    seq: 
+                      - type: str 
+                    desc: Field to select in the gain calibration table. Specify either the field number, name or as corrsponding to field spec in observation config, e.g. 'gcal'.
         
-      apply_transfer_fluxscale:
-        type: map
-        desc: Apply the fluxscale table to specified fields via the CASA applycal task.
-        mapping:
-          enable:
-            type: bool
-            desc: Executes application of fluxscale table.
-            required: true
-          field:
-            seq: 
-             - type: str 
-            desc: Field to select in the fluxscale table. Specify either the field number, name or as corrsponding to field spec in observation config, e.g. 'gcal'.
+              apply_transfer_fluxscale:
+                type: map
+                desc: Apply the fluxscale table to specified fields via the CASA applycal task.
+                mapping:
+                  enable:
+                    type: bool
+                    desc: Executes application of fluxscale table.
+                    required: true
+                  field:
+                    seq: 
+                      - type: str 
+                    desc: Field to select in the fluxscale table. Specify either the field number, name or as corrsponding to field spec in observation config, e.g. 'gcal'.
 
       changecentre:
         desc: changes the phase centre

--- a/meerkathi/workers/split_target_worker.py
+++ b/meerkathi/workers/split_target_worker.py
@@ -76,13 +76,13 @@ def worker(pipeline, recipe, config):
         tms = pipeline.cal_msnames[i]
         flagv = tms + '.flagversions'
 
-        if pipeline.enable_task(config, 'otfcal'):                #write calibration library file for OTF cal in split_target_worker.py
+        if pipeline.enable_task(config['split_target']	, 'otfcal'):                #write calibration library file for OTF cal in split_target_worker.py
             
 	    import getpass
 	    uname = getpass.getuser()
 	    gaintablelist,gainfieldlist,interplist = [],[],[]
-
-            calprefix = '{0:s}-{1:s}'.format(prefix, config['otfcal'].get('callabel', ''))            
+            callabel = config['split_target']['otfcal'].get('callabel', '')
+            calprefix = '{0:s}-{1:s}'.format(prefix, callabel)            
 
 	    for applyme in 'delay_cal bp_cal gain_cal_flux gain_cal_gain transfer_fluxscale'.split():
 		if not pipeline.enable_task(config, 'apply_'+applyme):
@@ -94,7 +94,7 @@ def worker(pipeline, recipe, config):
                 gainfieldlist.append(gainfield)
                 interplist.append(interp)
 
-            with open(os.path.join(pipeline.output, 'callib_target.txt'), 'w') as stdw:
+            with open(os.path.join(pipeline.output, 'callib_target_'+callabel+'.txt'), 'w') as stdw:
 		for j in range(len(gaintablelist)):
        			stdw.write('caltable=\'/home/'+uname+'/'+os.path.join(pipeline.output, gaintablelist[j])+'\'')
 			stdw.write(' calwt=False')
@@ -120,8 +120,8 @@ def worker(pipeline, recipe, config):
                     "correlation"   : config['split_target'].get('correlation', ''),
                     "field"         : str(target),
                     "keepflags"     : True,
-                    "docallib"      : config['otfcal'].get('enable', False),
-                    "callib"        : 'callib_target.txt',
+                    "docallib"      : config['split_target']['otfcal'].get('enable', False),
+                    "callib"        : 'callib_target_'+callabel+'.txt',
                 },
                 input=pipeline.input,
                 output=pipeline.output,


### PR DESCRIPTION
Added OTF calibration to MeerKATHI (AKA MHIRTO!). Please note that (a) polcal is not included, (b) frequency interpolation is hardcoded to be linear (where applicable). I can change later to be defined alongside time interpolation.

Things to change outside the workers I've modified:

- in the stimela parameter file of mstransform change the "io" of "callib" to "output" (instead of "input"), so mstransform looks for the callib file I write in output
- remove target from clearcal and applycal in the default config file (I'll let Josh know)