### PR TITLE
hireslabel_remove

### DIFF
--- a/meerkathi/default-config.yml
+++ b/meerkathi/default-config.yml
@@ -579,8 +579,6 @@
     enable: true
     order: 100
     label: hires
-    use_hires_data: false
-    hires_label: hires
     restfreq: 1.420405752GHz
     npix: [1024]
     cell: 7

--- a/meerkathi/schema/image_HI_schema-0.1.0.yml
+++ b/meerkathi/schema/image_HI_schema-0.1.0.yml
@@ -20,13 +20,6 @@ mapping:
         desc: Label of names of MS data sets to be used. MS data set names will always start with the data set id, followed by a hyphen, followed by desc. Default is corr.
         type: str
         required: false
-      hires_label:
-        desc: Label of names of High frequency resolution MS data sets to be used. MS data set names will always start with the data set id, followed by a hyphen, followed by desc. Default is hires.
-        type: str
-      use_hires_data:
-        desc: Make use of high resolution data for HI imaging
-        type: bool 
-        required: true
       restfreq:
         desc: Rest frequency default value for this worker. Default is '1.420405752GHz'.
         type: str

--- a/meerkathi/workers/flagging_worker.py
+++ b/meerkathi/workers/flagging_worker.py
@@ -50,14 +50,14 @@ def worker(pipeline, recipe, config):
         # Since the nobs are now equal to the length of the msnames if hires flagging is activated
         # It is important to have a p_nob that will look-up sources based on the original unique ms names in `pipeline`
         # Note: Flagging is still perfomed on all msnames using index i
-        if config['label'] and config['hires_flag']:
-            p_prefix = pipeline.prefixes
-            if config['label'] in prefix:
-                p_nob = p_prefix.index(prefix.replace('-{0:s}'.format(config['label']), ''))
-            elif config['hires_label'] in prefix:
-                p_nob = p_prefix.index(prefix.replace('-{0:s}'.format(config['hires_label']), ''))
-        else:
-            p_nob = i
+#        if config['label'] and config['hires_flag']:
+#            p_prefix = pipeline.prefixes
+#            if config['label'] in prefix:
+#                p_nob = p_prefix.index(prefix.replace('-{0:s}'.format(config['label']), ''))
+#            elif config['hires_label'] in prefix:
+#                p_nob = p_prefix.index(prefix.replace('-{0:s}'.format(config['hires_label']), ''))
+#        else:
+        p_nob = i
 
 
         # flag antennas automatically based on drifts in the scan average of the 

--- a/meerkathi/workers/image_HI_worker.py
+++ b/meerkathi/workers/image_HI_worker.py
@@ -96,8 +96,8 @@ def make_pb_cube(filename):
 
 NAME = 'Make HI Cube'
 def worker(pipeline, recipe, config):
-    mslist = ['{0:s}-{1:s}.ms'.format(did, config['hires_label']) for did in pipeline.dataid]  if config.get('use_hires_data', True) else ['{0:s}-{1:s}.ms'.format(did, config['label'])for did in pipeline.dataid]
-    pipeline.prefixes = ['meerkathi-{0:s}-{1:s}'.format(did,config['hires_label']) for did in pipeline.dataid] if config.get('use_hires_data', True) else  ['meerkathi-{0:s}-{1:s}'.format(did,config['label']) for did in pipeline.dataid]
+    mslist = ['{0:s}-{1:s}.ms'.format(did, config['label'])for did in pipeline.dataid]
+    pipeline.prefixes = ['meerkathi-{0:s}-{1:s}'.format(did,config['label']) for did in pipeline.dataid]
     prefixes = pipeline.prefixes
     restfreq = config.get('restfreq','1.420405752GHz')
     npix = config.get('npix', [1024])
@@ -110,8 +110,6 @@ def worker(pipeline, recipe, config):
     # Upate pipeline attributes (useful if, e.g., channel averaging was performed by the split_data worker)
     for i, prefix in enumerate(prefixes):
         msinfo = '{0:s}/{1:s}-obsinfo.json'.format(pipeline.output, prefix)
-        if config.get('use_hires_data', True):
-            msinfo = '{0:s}/{1:s}-obsinfo.json'.format(pipeline.output, prefix)
         meerkathi.log.info('Updating info from {0:s}'.format(msinfo))
         with open(msinfo, 'r') as stdr:
             spw = yaml.load(stdr)['SPW']['NUM_CHAN']
@@ -299,7 +297,7 @@ def worker(pipeline, recipe, config):
 
     if pipeline.enable_task(config, 'wsclean_image'):
         if config['wsclean_image'].get('use_mstransform',True):
-            mslist = ['{0:s}-{1:s}_mst.ms'.format(did, config['hires_label']) for did in pipeline.dataid]  if config.get('use_hires_data', True) else ['{0:s}-{1:s}_mst.ms'.format(did, config['label'])for did in pipeline.dataid]
+            mslist = ['{0:s}-{1:s}_mst.ms'.format(did, config['label'])for did in pipeline.dataid]
             # Upate pipeline attributes (useful if, e.g., the channelisation was changed by mstransform during this or a previous pipeline run)
             for i, prefix in enumerate(prefixes):
                 # If channelisation changed during a previous pipeline run as stored in the obsinfo.json file
@@ -329,7 +327,7 @@ def worker(pipeline, recipe, config):
                     pipeline.specframe[i]=[{'lsrd':0,'lsrk':1,'galacto':2,'bary':3,'geo':4,'topo':5}[config['mstransform'].get('outframe', 'bary')] for kk in pipeline.nchans[i]]
 
         else:
-            mslist = ['{0:s}-{1:s}.ms'.format(did, config['hires_label']) for did in pipeline.dataid]  if config.get('use_hires_data', True) else ['{0:s}-{1:s}.ms'.format(did, config['label'])for did in pipeline.dataid]
+            mslist = ['{0:s}-{1:s}.ms'.format(did, config['label'])for did in pipeline.dataid]
         spwid = config['wsclean_image'].get('spwid', 0)
         nchans = config['wsclean_image'].get('nchans',0)
         if nchans == 0 or nchans == 'all': nchans=pipeline.nchans[0][spwid]
@@ -526,7 +524,7 @@ def worker(pipeline, recipe, config):
 
     if pipeline.enable_task(config, 'casa_image'):
         if config['casa_image']['use_mstransform']:
-            mslist = ['{0:s}-{1:s}_mst.ms'.format(did, config['hires_label']) for did in pipeline.dataid]  if config.get('use_hires_data', True) else ['{0:s}-{1:s}_mst.ms'.format(did, config['label'])for did in pipeline.dataid]
+            mslist = ['{0:s}-{1:s}_mst.ms'.format(did, config['label']) for did in pipeline.dataid]
         step = 'casa_image_HI'
         spwid = config['casa_image'].get('spwid', 0)
         nchans = config['casa_image'].get('nchans', 0)

--- a/meerkathi/workers/self_cal_worker.py
+++ b/meerkathi/workers/self_cal_worker.py
@@ -48,7 +48,7 @@ def worker(pipeline, recipe, config):
     ncpu = config.get('ncpu', 9)
     mfsprefix = ["", '-MFS'][int(nchans>1)]
     cal_niter = config.get('cal_niter', 1)
-    hires_label = config['transfer_apply_gains'].get('transfer_to_label', 'hires')
+    hires_label = config['transfer_apply_gains'].get('transfer_to_label', '')
     pipeline.set_cal_msnames(label)
     pipeline.set_hires_msnames(hires_label)
     mslist = pipeline.cal_msnames
@@ -911,9 +911,6 @@ def worker(pipeline, recipe, config):
         if(calwith=='meqtrees'):
            enable = False
            meerkathi.log.info('Gains cannot be interpolated with MeqTrees, please switch to CubiCal')
-        hires_switch = config['calibrate'].get('hires_interpol', 'True')
-        if (hires_switch==False):
-            enable = False
         if config[key].get('Bjones',False):
             jones_chain = 'G,B'
         else:
@@ -1267,8 +1264,6 @@ def worker(pipeline, recipe, config):
     trace_matrix = []
 
     if pipeline.enable_task(config, 'image'):
-        if config['calibrate'].get('hires_interpol')==True:
-            meerkathi.log.info("Interpolating gains")
         image(self_cal_iter_counter)
     if pipeline.enable_task(config, 'sofia_mask'):
         sofia_mask(self_cal_iter_counter)

--- a/meerkathi/workers/split_target_worker.py
+++ b/meerkathi/workers/split_target_worker.py
@@ -151,24 +151,6 @@ def worker(pipeline, recipe, config):
                 output=pipeline.output,
                 label='{0:s}:: Change phase centre ms={1:s}'.format(step, tms))
 
-
-        if (pipeline.enable_task(config, 'changecentre') and pipeline.enable_task(config, 'hires_split')):
-            if config['changecentre'].get('ra','') == '' or config['changecentre'].get('dec','') == '':
-                meerkathi.log.error('Wrong format for RA and/or Dec you want to change to. Check your settings of split_target:changecentre:ra and split_target:changecentre:dec')
-                meerkathi.log.error('Current settings for ra,dec are {0:s},{1:s}'.format(config['changecentre'].get('ra',''),config['changecentre'].get('dec','')))
-                sys.exit(1)
-            step = 'changecentre_{:d}_hires'.format(i)
-            recipe.add('cab/casa_fixvis', step,
-                {
-                  "msname"  : fms,
-                  "outputvis": fms,
-                  "phasecenter" : 'J2000 {0:s} {1:s}'.format(config['changecentre'].get('ra',''),config['changecentre'].get('dec','')) ,
-                },
-                input=pipeline.input,
-                output=pipeline.output,
-                label='{0:s}:: Change phase centre ms={1:s}'.format(step, fms))
-
-
         if pipeline.enable_task(config, 'obsinfo'):
             if (config['obsinfo'].get('listobs', True) and pipeline.enable_task(config, 'split_target')):
                 step = 'listobs_{:d}'.format(i)
@@ -194,29 +176,3 @@ def worker(pipeline, recipe, config):
                 input=pipeline.input,
                 output=pipeline.output,
                 label='{0:s}:: Get observation information as a json file ms={1:s}'.format(step, tms))
-
-        if (pipeline.enable_task(config, 'obsinfo') and pipeline.enable_task(config, 'hires_split')):
-            if config['obsinfo'].get('listobs', True):
-                step = 'listobs_{:d}_hires'.format(i)
-                recipe.add('cab/casa_listobs', step,
-                    {
-                      "vis"         : fms,
-                      "listfile"    : '{0:s}-{1:s}-obsinfo.txt'.format(prefix, hires_label),
-                      "overwrite"   : True,
-                    },
-                    input=pipeline.input,
-                    output=pipeline.output,
-                    label='{0:s}:: Get observation information ms={1:s}'.format(step, tms))
-
-            if (config['obsinfo'].get('summary_json', True) and pipeline.enable_task(config, 'hires_split')):
-                 step = 'summary_json_{:d}_hires'.format(i)
-                 recipe.add('cab/msutils', step,
-                    {
-                      "msname"      : fms,
-                      "command"     : 'summary',
-                      "display"     : False,
-                      "outfile"     : '{0:s}-{1:s}-obsinfo.json'.format(prefix, hires_label),
-                    },
-                input=pipeline.input,
-                output=pipeline.output,
-                label='{0:s}:: Get observation information as a json file ms={1:s}'.format(step, fms))


### PR DESCRIPTION
Simplified pipeline by removing separate hires labels in some workers. These instead take a single label argument that sets on what ms they operate on. Note that hires_msnames remains in the pipeline, but it stays under the hood and is not necessarily referring to the unbinned full-res dataset.