### PR TITLE
fixed the <no pixels detected> after merging issue

### DIFF
--- a/meerkathi/workers/image_HI_worker.py
+++ b/meerkathi/workers/image_HI_worker.py
@@ -488,7 +488,7 @@ def worker(pipeline, recipe, config):
                 "steps.doFlag"          : False,
                 "steps.doScaleNoise"    : True,
                 "steps.doSCfind"        : True,
-                "steps.doMerge"         : False,
+                "steps.doMerge"         : True,
                 "steps.doReliability"   : False,
                 "steps.doParameterise"  : False,
        	        "steps.doWriteMask"     : True,


### PR DESCRIPTION
Changed the "merging" parameter in SoFiA to fix the issue of not detecting pixels after merging.