### PR TITLE
one line bug fix in split_target

### DIFF
--- a/meerkathi/workers/split_target_worker.py
+++ b/meerkathi/workers/split_target_worker.py
@@ -125,7 +125,6 @@ def worker(pipeline, recipe, config):
                         "datacolumn"    : config['split_target'].get('column', 'data'),
                         "correlation"   : config['split_target'].get('correlation', ''),
                         "field"         : field,
-                        "overwrite"     : True,
                         "keepflags"     : True,
                         "docallib"      : docallib,
                         "callib"        : sdm.dismissable(callib if pipeline.enable_task(config['split_target']	, 'otfcal') else None),


### PR DESCRIPTION
removed overwrite = True from the mstransform, as it's not a valid argument and will crash the pipeline. Sorry for adding it in the first place...