### PR TITLE
split target fixes

### DIFF
--- a/meerkathi/workers/split_target_worker.py
+++ b/meerkathi/workers/split_target_worker.py
@@ -30,6 +30,10 @@ table_suffix = {
 # Check if field was specified as known key, else return the
 # same value.
 
+def filter_name(string):
+    string = string.replace('+','_p_')
+    return re.sub('[^0-9a-zA-Z]', '_', string)
+
 def worker(pipeline, recipe, config):
 
     def get_field(field):
@@ -97,11 +101,10 @@ def worker(pipeline, recipe, config):
         else: docallib = False
 
         for target in target_ls:
+            field = filter_name(target)
 
-            field = re.sub('[^0-9a-zA-Z]', '_', target)
-
-            fms = pipeline.hires_msnames[i]
-            tms = '{0:s}-{1:s}-{2:s}.ms'.format(pipeline.msnames[i][:-3],field,label_out)
+            fms = [pipeline.hires_msnames[i] if label_in == '' else '{0:s}-{1:s}_{2:s}.ms'.format(pipeline.msnames[i][:-3],field,label_in)]
+            tms = '{0:s}-{1:s}_{2:s}.ms'.format(pipeline.msnames[i][:-3],field,label_out)
 
             flagv = tms+'.flagversions'
 
@@ -163,7 +166,7 @@ def worker(pipeline, recipe, config):
             if pipeline.enable_task(config, 'obsinfo'):
                 if (config['obsinfo'].get('listobs', True)):
                     if pipeline.enable_task(config, 'split_target'):
-                      listfile = '{0:s}-{1:s}-{2:s}-obsinfo.txt'.format(prefix,field,label_out)
+                        listfile = '{0:s}-{1:s}_{2:s}-obsinfo.txt'.format(prefix,field,label_out)
                     else: listfile = '{0:s}-obsinfo.txt'.format(prefix)
                 
                     step = 'listobs_{:d}'.format(i)
@@ -179,7 +182,7 @@ def worker(pipeline, recipe, config):
     
                 if (config['obsinfo'].get('summary_json', True)):
                     if pipeline.enable_task(config, 'split_target'):
-                        listfile = '{0:s}-{1:s}-{2:s}-obsinfo.json'.format(prefix,field,label_out)
+                        listfile = '{0:s}-{1:s}_{2:s}-obsinfo.json'.format(prefix,field,label_out)
                     else: listfile = '{0:s}-obsinfo.json'.format(prefix)
                 
                     step = 'summary_json_{:d}'.format(i)


### PR DESCRIPTION
-Underscores instead of hyphen between filed name and label so fieldname+label can be used as new label for other workers.

- function to remove unwanted characters from target names

- if label_in is not empty, mstransform will take the already splitted individual target ms's as input instead of the base ms