### PR TITLE
fix obsinfo.json prefix in image_HI worker

### DIFF
--- a/meerkathi/workers/image_HI_worker.py
+++ b/meerkathi/workers/image_HI_worker.py
@@ -123,7 +123,7 @@ def calc_rms(filename,HImaskname):
 NAME = 'Make HI Cube'
 def worker(pipeline, recipe, config):
     mslist = ['{0:s}-{1:s}.ms'.format(did, config['label'])for did in pipeline.dataid]
-    pipeline.prefixes = ['meerkathi-{0:s}-{1:s}'.format(did,config['label']) for did in pipeline.dataid]
+    pipeline.prefixes = ['{2:s}-{0:s}-{1:s}'.format(did,config['label'],pipeline.prefix) for did in pipeline.dataid]
     prefixes = pipeline.prefixes
     restfreq = config.get('restfreq','1.420405752GHz')
     npix = config.get('npix', [1024])


### PR DESCRIPTION
This change is probably already implemented in the branches where @mpatir and @molnard89 are setting the stage for mosaicking -- but here it is anyway, just to make it possible to run the image_HI worker of the master branch successfully.