### PR TITLE
Fix issue#483

### DIFF
--- a/meerkathi/workers/self_cal_worker.py
+++ b/meerkathi/workers/self_cal_worker.py
@@ -566,12 +566,12 @@ def worker(pipeline, recipe, config):
             step = 'convert_extract_{0:d}'.format(num)
             recipe.add('cab/tigger_convert', step,
                        {
-                           "input-skymodel"   : calmodel + '.gaul',
+                           "input-skymodel"   : calmodel + '.gaul:output',
                            "output-skymodel"  : calmodel + '.lsm.html',
                            "type"             : 'Gaul',
                            "output-type"      : 'Tigger',
                        },
-                       input = pipeline.output,
+                       input = pipeline.input,
                        output = pipeline.output,
                        label = '{0:s}:: Convert extracted sources to tigger model'.format(step))
         elif sourcefinder == 'sofia': 


### PR DESCRIPTION
Split the PYBDSM conversion to tigger file such that we can check sources are found and the pipeline exits when no sources are found.

This went through a full pipeline test without the inspect_data test because that threw the following error

meerkathi - 2019-06-28 16:06:34,915 INFO - casa.qtapp: cannot connect to X server :99
meerkathi - 2019-06-28 16:06:34,915 INFO - Traceback (most recent call last):
meerkathi - 2019-06-28 16:06:34,915 INFO -   File "/scratch/code/run.py", line 27, in <module>
meerkathi - 2019-06-28 16:06:34,915 INFO -     task.run()
meerkathi - 2019-06-28 16:06:34,915 INFO -   File "/usr/local/lib/python2.7/dist-packages/Crasa/Crasa.py", line 105, in run
meerkathi - 2019-06-28 16:06:34,915 INFO -     "-c", tfile.name])
meerkathi - 2019-06-28 16:06:34,915 INFO -   File "/usr/lib/python2.7/subprocess.py", line 541, in check_call
meerkathi - 2019-06-28 16:06:34,916 INFO -     raise CalledProcessError(retcode, cmd)

Which appears more like a singularity/running in screen than a pipeline related error to me.