### PR TITLE
Change minimal conf so that #684 is sorted.

### DIFF
--- a/meerkathi/sample_configurations/minimalConfig.yml
+++ b/meerkathi/sample_configurations/minimalConfig.yml
@@ -65,9 +65,11 @@
 
 - image_line:
     enable: true
-    npix: [1800]
-    cell: 2
     restfreq: '1.420405752GHz'
+    make_cube: 
+      enable: true
+      npix: [1800]
+      cell: 2
     mstransform: 
       enable: true
       telescope: meerkat


### PR DESCRIPTION
Adds make_cube in minimalConfig.yml and shifts npix and cell parameters under it in the image_line worker. Fixes #684 .