### PR TITLE
Shift the time and frequency chunk options

### DIFF
--- a/meerkathi/schema/self_cal_schema-0.2.0.yml
+++ b/meerkathi/schema/self_cal_schema-0.2.0.yml
@@ -528,16 +528,6 @@ mapping:
             desc: label of cross-calibrated .ms file to which to transfer and apply the selfcal gains
             required: false
             example: 'corr'
-          time_chunk:
-            type: int
-            desc: Time chunk in units of timeslots for transferring gains with Cubical.
-            required: false
-            example: '128'
-          freq_chunk:
-            type: int
-            desc: Frequency chunk in units of channels for transferring gains with Cubical. '0' means the whole spw.
-            required: false
-            example: '0'
           interpolate:
             type: map
             desc: To interpolate the gains or not to interpolate the gains. That is indeed the question.
@@ -557,7 +547,16 @@ mapping:
                  desc: Solution interval in frequency (units of channels) to transfer gains.
                  required: false
                  example: '0'     
-          
+              time_chunk:
+                 type: int
+                 desc: Time chunk in units of timeslots for transferring gains with Cubical.
+                 required: false
+                 example: '128'
+              freq_chunk:
+                 type: int
+                 desc: Frequency chunk in units of channels for transferring gains with Cubical. '0' means the whole spw.
+                 required: false
+                 example: '0'
 
       transfer_model:
         type: map

--- a/meerkathi/workers/self_cal_worker.py
+++ b/meerkathi/workers/self_cal_worker.py
@@ -1104,8 +1104,8 @@ def worker(pipeline, recipe, config):
        #     bupdate = 'full'
        #     dupdate = 'full'
 
-        time_chunk_interp = config['transfer_apply_gains'].get('time_chunk')
-        freq_chunk_interp = config['transfer_apply_gains'].get('freq_chunk')
+        time_chunk_interp = config['transfer_apply_gains']['interpolate'].get('time_chunk')
+        freq_chunk_interp = config['transfer_apply_gains']['interpolate'].get('freq_chunk')
         for i, msname_out in enumerate(mslist_out):
             ##Read the time and frequency channels of the  'fullres' 
             fullres_data = get_obs_data(msname_out)
@@ -1128,6 +1128,7 @@ def worker(pipeline, recipe, config):
                 "data-ms": msname_out,
                 "data-column": 'DATA',
                 "log-boring": True,
+                "g-solvable" : False,
                 "sol-jones": jones_chain,
                 "sel-ddid": sdm.dismissable(config['calibrate'].get('spwid')),
                 "dist-ncpu": ncpu,


### PR DESCRIPTION
Move the time and frequency chunk options in the self-cal gain interpolation to the interpolate section (when using xfer-from), since when using load-from options, the time and frequency chunks are decided automatically.