### PR TITLE
No intents

### DIFF
--- a/meerkathi/dispatch_crew/utils.py
+++ b/meerkathi/dispatch_crew/utils.py
@@ -41,7 +41,7 @@ def categorize_fields(msinfo):
         'bpcal': (['CALIBRATE_BANDPASS'], []),
         'target': (['TARGET'], []),
         'xcal': (['CALIBRATE_POLARIZATION'], [])
-        }
+    }
     if intents != None:
         for i, field in enumerate(names):
             ints = intents[intent_ids[i]].split(',')

--- a/meerkathi/workers/observation_config_worker.py
+++ b/meerkathi/workers/observation_config_worker.py
@@ -141,7 +141,6 @@ def worker(pipeline, recipe, config):
             targetinfo = yaml.safe_load(stdr)['FIELD']
 
         intents = utils.categorize_fields(msinfo)
-        print(intents)
         # The order of fields here is important
         for term in "target gcal fcal bpcal xcal".split():
             conf_fields = getattr(pipeline, term)[i]


### PR DESCRIPTION
For when your observatory does not write the intentions of the fields in the header. See #728 for more details on the necessity of this branch.