### PR TITLE
Fix in flag spw valid selection when only 1 spw is listed

### DIFF
--- a/meerkathi/sample_configurations/meerkat-defaults.yml
+++ b/meerkathi/sample_configurations/meerkat-defaults.yml
@@ -47,7 +47,7 @@ flagging:
   flag_spw:
     enable: true
     channels: '*:856~880MHz , *:1658~1800MHz, *:1419.8~1421.3MHz'
-    ensure_valid_selection: false #TODO(Paolo, I think) this is not working
+    ensure_valid_selection: false
   flag_antennas:
     enable: false
     antennas: '0'

--- a/meerkathi/workers/flagging_worker.py
+++ b/meerkathi/workers/flagging_worker.py
@@ -203,10 +203,10 @@ def worker(pipeline, recipe, config):
                         'GHz': 1e+9, 'MHz': 1e+6, 'kHz': 1e+3}
                     for ff in flagspwselection.split(','):
                         for dd in scalefactor_dict:
-                            if dd in ff:
-                                ff, scalefactor = ff.replace(
-                                    dd, ''), scalefactor_dict[dd]
-                        ff = ff.replace('Hz', '').split(':')
+                            if dd.lower() in ff.lower():
+                                ff, scalefactor = ff.lower().replace(
+                                    dd.lower(), ''), scalefactor_dict[dd]
+                        ff = ff.lower().replace('hz', '').split(':')
                         if len(ff) > 1:
                             spws = ff[0]
                         else:
@@ -219,7 +219,7 @@ def worker(pipeline, recipe, config):
                             spws = list(
                                 range(int(spws.split('~')[0]), int(spws.split('~')[1])+1))
                         else:
-                            spws = [spws, ]
+                            spws = [int(spws), ]
                         edges = [edges for uu in range(len(spws))]
                         for ss in spws:
                             if ss < len(pipeline.lastchanfreq[i]) and min(edges[ss][1], pipeline.lastchanfreq[i][ss])-max(edges[ss][0], pipeline.firstchanfreq[i][ss]) > 0:


### PR DESCRIPTION
The check for whether the spw flagging selection is valid would fail when a single spw was given, e.g., 0:1380Mhz~1385MHz. 

Also made the unit comparison case insensitive to not be bothered by the difference between MHz, Mhz, MHZ.