### PR TITLE
Addressing conflicts with stimela updates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
--e git+https://github.com/SpheMakh/Stimela@21f07e9fe883feeb2d46e69ab183b03315477a85#egg=stimela
+-e git+https://github.com/SpheMakh/Stimela@f94417e9cf3bca57e68e9d4c2db9624b33c829d5#egg=stimela

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ requirements = [
     'ruamel.yaml>=0.16.6',
     'decorator>=4.4.1',
     'numpy>=1.18.1',
-    'stimela>=1.2.4',
+    'stimela @ git+https://github.com/SpheMakh/Stimela',
     'scipy>=1.4.1',
     'pysolr>=3.8.1',
     'progressbar2>=3.47.0',


### PR DESCRIPTION
Fix for issues (#815 ,) #803, #685 , #513, #683, #812 , all of which address the same problem: if one pulls the newest Stimela, as setup.py and until now requirements.txt would initiate, upgrades in stimela might be incompatible with MeerKATHI. A conflict like #815 will arise without changing a formerly running meerkathi version. A simple warning like #812 is not sufficient, as it is impossible to track 84 issues, at least for me.

The "solution", following the suggestions discussed in #803 , is to fix the Stimela commit in requirements.txt . Even if this seems ugly, we somehow need to maintain a pointer to a compatible Stimela version.

For this current pull request, following the suggestions discussed in #803 , setup.py does not specify specific releases, but requirements.txt does specify the specific Stimela commit. In the future, before creating a pull request, one test should always be run with setup.py[beta] only, refreshing Stimela.
```
> pip install -U -I "${wherevermeerkathiis}/meerkathi[beta]"
> docker system prune
> stimela pull -d
> stimela build
> meerkathi -gd ...
> meerkathi -c ...
```
 If that is successful, look up the current Stimela commit (you can find the precise identifyer [on the stimela main page](https://github.com/ratt-ru/Stimela), clicking on the number next to the line 'Latest commit') and replace it in requirements.txt. Then run another test using requirements.txt.
```
> pip install -U -I "${wherevermeerkathiis}/meerkathi[beta]"
> pip install -U -I -r "${wherevermeerkathiis}/meerkathi/requirements.txt"
> docker system prune
> stimela pull -d
> stimela build
> meerkathi -gd ...
> meerkathi -c ...
```
Reviewers should do the same. Again,
**Please notice that this pull request is fixing the Stimela commit in requirements.txt**. For new pull requests ``requirements.txt`` therefore needs to be checked before creating issuing the pulll request and then adjusted to the right stimela commit in a manner as e.g. suggested above.

This will prevent issues like #815 in the future and always guarantee that if one installs the current meerkathi version using requirements.txt, one will have an operational version even if Stimela gets updated. If one wants to run and test meerkathi with an updated Stimela version, (re-)install while not using requirements.txt .

For now, my intention was to only create a version that will run when using requirements.txt, because otherwise MeerKATHI is broken. @KshitijT, it would be great if you could address #815 with the updated stimela/cubical still. That is not yet done. 

I will also create a new Jenkins test asap.