### PR TITLE
Fix the pathformatter syntax for modellist in selfcal worker

### DIFF
--- a/meerkathi/workers/self_cal_worker.py
+++ b/meerkathi/workers/self_cal_worker.py
@@ -912,10 +912,15 @@ def worker(pipeline, recipe, config):
         ## In pybdsm_vis mode, add the calmodel (pybdsf) and the MODEL_DATA. 
         if config[key].get('model_mode') == 'pybdsm_vis':
             if (num == cal_niter):
-                modellist = [calmodel, 'MODEL_DATA']
+                cmodel = calmodel.split(":output")[0]
+                modellist = spf("MODEL_DATA+"+'{}/'+cmodel,"output")
+
+                #modellist = [calmodel, 'MODEL_DATA']
         # otherwise, just calmodel (pybdsf)
             else:
-                modellist = [calmodel]
+                #modellist = [calmodel]
+                cmodel = calmodel.split(":output")[0]
+                modellist = spf("{}/"+cmodel,"output")
             # This is incorrect and will result in the lsm being used in the first direction
             # and the model_data in the others. They need to be added as + however
             # that messes up the output identifier structure    


### PR DESCRIPTION
..I hope to the dark gods I have got the syntax right.

Please test this using the test data, while using carateconfig.yml modified in the self cal section as:
```
self_cal:
  enable: true
  img_npix: 1800
  img_cell: 2
  image:
    enable: true
  calibrate:
    enable: true
    Gsols_time: [120]
    model_mode: 'pybdsm_vis'
  extract_sources:
    enable: true
```