### PR TITLE
typos_sarah2

### DIFF
--- a/caracal/schema/flag_schema.yml
+++ b/caracal/schema/flag_schema.yml
@@ -279,7 +279,7 @@ mapping:
                 required: False
                 example: 'firstpass_Q.rfis'
               ensure_valid:
-                desc: Ensure that the selected AOFlagger strategy is compatible with the type of correlations present in the input .MS file(s). E.g., attempts to flag on Stokes V an .MS with XX and YY only will result in an error and exit Caracal. The rules are 1) XY,YX present to flag on Stokes V,U or on XY,YX, 2) XX,YY present to flag on Stokes I,Q or on XX,YY. Disable only if you know what you are doing.
+                desc: Ensure that the selected AOFlagger strategy is compatible with the type of correlations present in the input .MS file(s). E.g., attempts to flag on Stokes V for an .MS with XX and YY only will result in an error and CARACal exiting. The rules are 1. XY,YX must be present in order to flag on Stokes V,U (or on XY,YX), and 2. XX,YY must be present in order to flag on Stokes I,Q (or on XX,YY). Disable this parameter only if you know what you are doing.
                 type: bool
                 required: False
                 example: 'True'


### PR DESCRIPTION
@svw26 your last comment was:

I don't want to mess up flag_schema.yml by pushing my own commit, so please just make sure that line 282 uses the following text:

desc: Ensure that the selected AOFlagger strategy is compatible with the type of correlations present in the input .MS file(s). E.g., attempts to flag on Stokes V for an .MS with XX and YY only will result in an error and CARACal exiting. The rules are 1. XY,YX must be present in order to flag on Stokes V,U (or on XY,YX), and 2. XX,YY must be present in order to flag on Stokes I,Q (or on XX,YY). Disable this parameter only if you know what you are doing.

"only thing left" in terms of what I could find in the space of 40 minutes this morning.