### PR TITLE
Change flag label

### DIFF
--- a/caracal/sample_configurations/meerkat-defaults.yml
+++ b/caracal/sample_configurations/meerkat-defaults.yml
@@ -28,7 +28,7 @@ prep:
 flag:
   enable: true
   field: calibrators
-  label_in: ''
+  label_in: cal
   flag_autocorr:
     enable: true
   flag_spw:


### PR DESCRIPTION
PR changes the flag__1 worker input label to 'cal' for the meerkat defaults - otherwise flags the _original_ ms, not cal datasets. This is potentially pretty dangerous since the AOFlagger strategies perform an '' OR" with preexisting flags - leading the later flag__2 to possibly overflag, not to mention calibrators won't be flagged at all.