### PR TITLE
Inspect target in original and splitted data

### DIFF
--- a/caracal/sample_configurations/carateConfig.yml
+++ b/caracal/sample_configurations/carateConfig.yml
@@ -44,7 +44,8 @@ flag:
 
 inspect:
   label_in: 'cal'
-  label_cal: 'pre1gc'
+  field: 'calibrators'
+  label_plot: 'pre1gc'
   enable: true
   dirname: initial
   shadems:
@@ -99,7 +100,8 @@ crosscal:
 
 inspect__2:
   label_in: 'cal'
-  label_cal: '1gc'
+  field: 'calibrators'
+  label_plot: '1gc'
   enable: true
   dirname: crosscal
   shadems:

--- a/caracal/sample_configurations/meerkat-continuum-defaults.yml
+++ b/caracal/sample_configurations/meerkat-continuum-defaults.yml
@@ -76,7 +76,7 @@ crosscal:
 inspect: 
   enable: true
   label_in: 'cal'
-  label_cal: '1gc'
+  label_plot: '1gc'
   fields:
     - bpcal
     - gcal

--- a/caracal/sample_configurations/meerkat-defaults.yml
+++ b/caracal/sample_configurations/meerkat-defaults.yml
@@ -78,7 +78,7 @@ crosscal:
 inspect:
   enable: true
   label_in: 'cal'
-  label_cal: '1gc'
+  label_plot: '1gc'
   fields:
     - bpcal
     - gcal

--- a/caracal/sample_configurations/minimalConfig.yml
+++ b/caracal/sample_configurations/minimalConfig.yml
@@ -46,7 +46,7 @@ crosscal:
 
 inspect:
   label_in: cal
-  label_cal: 1gc
+  label_plot: 1gc
   dirname: crosscal
   enable: true
 

--- a/caracal/sample_configurations/minitestConfig.yml
+++ b/caracal/sample_configurations/minitestConfig.yml
@@ -50,7 +50,7 @@ crosscal:
 
 inspect:
   label_in: cal
-  label_cal: 1gc
+  label_plot: 1gc
   dirname: crosscal
   enable: true
   standard_plotter: ragavi_vis

--- a/caracal/sample_configurations/workflow_new.yml
+++ b/caracal/sample_configurations/workflow_new.yml
@@ -94,7 +94,8 @@ crosscal:
 inspect:
   enable: true
   label_in: 'cal'
-  label_cal: '1gc1'
+  field: 'calibrators'
+  label_plot: '1gc1'
   fields:
     - bpcal
     - gcal

--- a/caracal/schema/inspect_schema.yml
+++ b/caracal/schema/inspect_schema.yml
@@ -14,7 +14,12 @@ mapping:
         type: str
         required: false
         example: ''
-      label_cal: 
+      field:
+        desc: Fields that should be inspected. It can be set to 'target', 'calibrators' (i.e., all calibrators) or any comma-separated combination of 'fcal','bpcal','gcal', as defined in the obsconf worker. N$
+        type: str
+        required: False
+        example: 'calibrators'
+      label_plot: 
         type: str
         desc: Label for output products (plots etc.) for this step.
         required: false
@@ -81,12 +86,6 @@ mapping:
         required: false
         desc: Set the U-V range for data selection, e.g. '>50'.
         example: '' 
-      fields: 
-        seq:
-          - type: str
-        required: false
-        desc: Fields to plot. Specify by field id, index or keys like, gcal, bpcal.
-        example: 'bpcal, gcal'
 
       real_imag:
         type: map
@@ -97,12 +96,6 @@ mapping:
             desc: Executed the real v/s imaginary data plotting.
             required: false
             example: 'False'
-          fields:
-            seq:
-              - type: str
-            desc: Fields to plot. Specify by field id, index or keys like, gcal, bpcal.
-            required: false
-            example: ''
           col: 
             type: str
             desc: Data column to plot.
@@ -128,12 +121,6 @@ mapping:
             desc: Executes the plotting of amplitude v/s phase for data.
             required: false
             example: 'False'
-          fields:
-            seq:
-              - type: str
-            desc: "Fields to plot. Specify by field id, index or keys like: gcal, bpcal."
-            required: false
-            example: ''
           col:
             type: str
             desc: Data column to plot.
@@ -159,12 +146,6 @@ mapping:
             desc: Executes plotting data amplitude as a function of uvwave.
             required: false
             example: 'False'
-          fields:
-            seq:
-              - type: str
-            desc: "Fields to plot. Specify by field id, index or keys like: gcal, bpcal."
-            required: false
-            example: ''
           col:
             type: str
             desc: Data column to plot.
@@ -190,12 +171,6 @@ mapping:
             desc: Executes plotting data amplitude v/s antennas.
             required: false
             example: 'False'
-          fields:
-            seq:
-              - type: str
-            desc: "Fields to plot. Specify by field id, index or keys like: gcal, bpcal."
-            required: false
-            example: ''
           col:
             type: str
             desc: Data column to plot.
@@ -221,12 +196,6 @@ mapping:
             desc: Executes plotting data phase v/s uvwave.
             required: false
             example: 'False'
-          fields:
-            seq:
-              - type: str
-            desc: "Fields to plot. Specify by field id, index or keys like: gcal, bpcal."
-            required: false
-            example: ''
           col:
             type: str
             desc: Data column to plot.
@@ -252,12 +221,6 @@ mapping:
             desc: Executes plotting data amplitude v/s scan number.
             required: false
             example: 'False'
-          fields:
-            seq:
-              - type: str
-            desc: "Fields to plot. Specify by field id, index or keys like: gcal, bpcal."
-            required: false
-            example: ''
           col:
             type: str
             desc: Data column to plot.
@@ -283,12 +246,6 @@ mapping:
             desc: Executes the plotting of amplitude v/s phase for data.
             required: false
             example: 'False'
-          fields:
-            seq:
-              - type: str
-            desc: "Fields to plot. Specify by field id, index or keys like: gcal, bpcal."
-            required: false
-            example: ''
           col:
             type: str
             desc: Data column to plot.
@@ -314,12 +271,6 @@ mapping:
             desc: Executes the plotting of amplitude v/s phase for data.
             required: false
             example: 'False'
-          fields:
-            seq:
-              - type: str
-            desc: "Fields to plot. Specify by field id, index or keys like: gcal, bpcal."
-            required: false
-            example: ''
           col:
             type: str
             desc: Data column to plot.

--- a/caracal/workers/inspect_worker.py
+++ b/caracal/workers/inspect_worker.py
@@ -7,6 +7,8 @@ import yaml
 from stimela.dismissable import dismissable as sdm
 from caracal import log
 import caracal.dispatch_crew.utils as utils
+import numpy as np
+import json
 
 NAME = 'Inspect Data'
 LABEL = "inspect"
@@ -110,15 +112,9 @@ def ragavi_vis(pipeline, recipe, config, plotname, msname, field, iobs, label, p
 
 def worker(pipeline, recipe, config):
 
-    def specific_fields(sec):
-        if config[sec]['fields'] in ["", [""], None, "null"]:
-            return False
-        else:
-            return config[sec]['fields']
-
     uvrange = config['uvrange']
-    fields = config['fields']
-    plotter = config["standard_plotter"]
+    plotter = config['standard_plotter']
+
     if pipeline.virtconcat:
         msnames = [pipeline.vmsname]
         prefixes = [pipeline.prefix]
@@ -132,199 +128,243 @@ def worker(pipeline, recipe, config):
     output_dir = os.path.join(pipeline.diagnostic_plots, subdir) if subdir else pipeline.diagnostic_plots
 
     for iobs in range(nobs):
-        msname = msnames[iobs] if not config['label_in'] else '{0:s}_{1:s}.ms'.format(
-            msnames[iobs][:-3], config['label_in'])
+
         prefix = prefixes[iobs]
-        label = config['label_cal']
+        fields = config['field'].split(',')
 
-        msinfo = '{0:s}/{1:s}-obsinfo.json'.format(pipeline.obsinfo, msname[:-3])
+        if 'calibrators' in fields:
+            fields = ['fcal','bpcal','gcal']
 
-        corr = config['correlation']
-        if corr == 'auto':
-            with open(msinfo, 'r') as stdr:
-                corrs = yaml.load(stdr)['CORR']['CORR_TYPE']
-            corrs = ','.join(corrs)
-            corr = corrs
+        for fd in fields:
+            if fd not in ['target','fcal','bpcal','gcal']:
+                raise ValueError("Eligible values for 'field': 'target', 'calibrators', 'fcal', 'bpcal' or 'gcal'. "\
+                                 "User selected: {}".format(field_to_split))
 
-        # new-school plots
-        if config['shadems']['enable']:
-            plot_args = []
-            # get field names
-            for field_type in fields:
-                field_names = getattr(pipeline, field_type)[iobs]
+#        if any(x in fields for x in ['fcal','bpcal','gcal']):
+#           calfields = []
+#           for fd in fields:
+#               for elem in getattr(pipeline, fd)[iobs]:
+#                   calfields.append(elem)
+#           field_names = [','.join(np.unique(np.array(calfields))),]
+#        else:
+#           field_names = pipeline.target[iobs]
+
+        '''GET LIST OF INPUT MS'''
+        mslist = []
+        msn = pipeline.msnames[iobs][:-3]
+        label = config['label_plot']
+        label_in = config['label_in']
+
+        if not label_in:
+            mslist.append(pipeline.msnames[iobs])
+        elif config['field'] == 'target':
+            for target in pipeline.target[iobs]:
+                field = utils.filter_name(target)
+                mslist.append('{0:s}-{1:s}_{2:s}.ms'.format(msn, field, label_in))
+        else:
+            mslist.append('{0:s}_{1:s}.ms'.format(msn, label_in))
+
+        for m in mslist:
+            if not os.path.exists(os.path.join(pipeline.msdir, m)):
+                raise IOError(
+                    "MS file {0:s} does not exist. Please check that is where it should be.".format(m))
+
+        for msname in mslist:
+
+            msinfo = '{0:s}/{1:s}-obsinfo.json'.format(pipeline.obsinfo, msname[:-3])
+
+            corr = config['correlation']
+            if corr == 'auto':
+                with open(msinfo, 'r') as stdr:
+                    corrs = yaml.load(stdr)['CORR']['CORR_TYPE']
+                corrs = ','.join(corrs)
+                corr = corrs
+
+            # new-school plots
+            if config['shadems']['enable']:
+                plot_args = []
+                # get field names
+                for field_type in fields:
+
+                    if (label_in != '') and (config['field'] == 'target'):
+                        with open(msinfo, 'r') as stdr:
+                            field_names = yaml.load(stdr,Loader=yaml.FullLoader)['FIELD']['NAME']
+                    else:
+                        field_names = getattr(pipeline, field_type)[iobs]
+
+                    args = OrderedDict(
+                                # shadems uses its own "{}" codes in output name, so put it together like this
+                                png="{}-{}-{}-{}".format(prefix, label, field_type,
+                                    "{field}{_Spw}{_Scan}{_Ant}-{label}{_alphalabel}{_colorlabel}{_suffix}.png"),
+                                title="'{ms} "+field_type + "{_field}{_Spw}{_Scan}{_Ant}{_title}{_Alphatitle}{_Colortitle}'",
+                                col=config['shadems']['default_column'],
+                                corr=corr.replace(' ',''),
+                                field=",".join(field_names))
+
+                    for iplot, plotspec in enumerate(config['shadems']['plots_by_field']):
+                        if plotspec:
+                            plotspec = plotspec.split()
+                            for arg, value in args.items():
+                                arg = "--" + arg
+                                if arg not in plotspec:
+                                    plotspec += [arg, value]
+                            plotspec.append("--iter-field")
+                            plot_args.append(" ".join(plotspec))
+
                 args = OrderedDict(
-                            # shadems uses its own "{}" codes in output name, so put it together like this
-                            png="{}-{}-{}-{}".format(prefix, label, field_type,
-                                "{field}{_Spw}{_Scan}{_Ant}-{label}{_alphalabel}{_colorlabel}{_suffix}.png"),
-                            title="'{ms} "+field_type + "{_field}{_Spw}{_Scan}{_Ant}{_title}{_Alphatitle}{_Colortitle}'",
-                            col=config['shadems']['default_column'],
-                            corr=corr.replace(' ',''),
-                            field=",".join(field_names))
-
-                for iplot, plotspec in enumerate(config['shadems']['plots_by_field']):
+                    # shadems uses its own "{}" codes in output name, so put it together like this
+                    png="{}-{}-{}".format(prefix, label,
+                                          "{field}{_Spw}{_Scan}{_Ant}-{label}{_alphalabel}{_colorlabel}{_suffix}.png"),
+                    title="'{ms} {_field}{_Spw}{_Scan}{_Ant}{_title}{_Alphatitle}{_Colortitle}'",
+                    col=config['shadems']['default_column'],
+                    corr=corr.replace(' ', ''))
+                for iplot, plotspec in enumerate(config['shadems']['plots_by_corr']):
                     if plotspec:
                         plotspec = plotspec.split()
                         for arg, value in args.items():
                             arg = "--" + arg
                             if arg not in plotspec:
                                 plotspec += [arg, value]
-                        plotspec.append("--iter-field")
+                        plotspec.append("--iter-corr")
                         plot_args.append(" ".join(plotspec))
 
-            args = OrderedDict(
-                # shadems uses its own "{}" codes in output name, so put it together like this
-                png="{}-{}-{}".format(prefix, label,
-                                      "{field}{_Spw}{_Scan}{_Ant}-{label}{_alphalabel}{_colorlabel}{_suffix}.png"),
-                title="'{ms} {_field}{_Spw}{_Scan}{_Ant}{_title}{_Alphatitle}{_Colortitle}'",
-                col=config['shadems']['default_column'],
-                corr=corr.replace(' ', ''))
-            for iplot, plotspec in enumerate(config['shadems']['plots_by_corr']):
-                if plotspec:
-                    plotspec = plotspec.split()
-                    for arg, value in args.items():
-                        arg = "--" + arg
-                        if arg not in plotspec:
-                            plotspec += [arg, value]
-                    plotspec.append("--iter-corr")
-                    plot_args.append(" ".join(plotspec))
 
-
-            if plot_args:
-                step = 'plot-shadems-ms{2:d}'.format(iplot, field_type, iobs)
-                recipe.add("cab/shadems_direct", step,
-                           dict(ms=msname, args=plot_args,
-                                ignore_errors=config["shadems"]["ignore_errors"]),
-                           input=pipeline.input, output=output_dir,
-                           label="{0:s}:: Plotting".format(step))
-            else:
-                log.warning("The shadems section is enabled, but doesn't specify any plot_by_field or plot_by_corr")
-
-        # old-school plots
-
-        # define plot attributes
-        diagnostic_plots = {}
-        diagnostic_plots["real_imag"] = dict(
-            plotms={"xaxis": "imag", "yaxis": "real",
-                    "colouraxis": "baseline", "iteraxis": "corr"},
-            shadems={"xaxis": "real", "yaxis": "imag"},
-            ragavi_vis={"xaxis": "real", "yaxis": "imaginary",
-                        "iter-axis": "scan", "canvas-width": 300,
-                        "canvas-height": 300})
-
-        diagnostic_plots["amp_phase"] = dict(
-            plotms={"xaxis": "amp", "yaxis": "phase",
-                    "colouraxis": "baseline", "iteraxis": "corr"},
-            shadems={"xaxis": "amp", "yaxis": "phase"},
-            ragavi_vis={"xaxis": "phase", "yaxis": "amplitude",
-                        "iter-axis": "corr", "canvas-width": 1080,
-                        "canvas-height": 720})
-
-        diagnostic_plots["amp_ant"] = dict(
-            plotms={"xaxis": "antenna", "yaxis": "amp",
-                    "colouraxis": "baseline", "iteraxis": "corr"},
-            shadems={"xaxis": "ANTENNA1", "yaxis": "amp"},
-            ragavi_vis=None)
-
-        diagnostic_plots["amp_uvwave"] = dict(
-            plotms={"xaxis": "uvwave", "yaxis": "amp",
-                    "colouraxis": "baseline", "iteraxis": "corr"},
-            shadems={"xaxis": "UV", "yaxis": "amp"},
-            ragavi_vis={"xaxis": "uvwave", "yaxis": "amplitude",
-                        "iter-axis": "scan", "canvas-width": 300,
-                        "canvas-height": 300})
-
-        diagnostic_plots["phase_uvwave"] = dict(
-            plotms={"xaxis": "uvwave", "yaxis": "phase",
-                    "colouraxis": "baseline", "iteraxis": "corr"},
-            shadems={"xaxis": "UV", "yaxis": "phase"},
-            ragavi_vis={"xaxis": "uvwave", "yaxis": "phase",
-                        "iter-axis": "scan", "canvas-width": 300,
-                        "canvas-height": 300})
-
-        diagnostic_plots["amp_scan"] = dict(
-            plotms={"xaxis": "scan", "yaxis": "amp"},
-            shadems={"xaxis": "SCAN_NUMBER", "yaxis": "amp"},
-            ragavi_vis={"xaxis": "scan", "yaxis": "amplitude",
-                        "iter-axis": None,
-                        "canvas-width": 1080, "canvas-height": 720})
-
-        diagnostic_plots["amp_chan"] = dict(
-            plotms={"xaxis": "chan", "yaxis": "amp"},
-            shadems={"xaxis": "CHAN", "yaxis": "amp"},
-            ragavi_vis={"xaxis": "channel", "yaxis": "amplitude",
-                        "iter-axis": "scan", "canvas-width": 300,
-                        "canvas-height": 300})
-
-        diagnostic_plots["phase_chan"] = dict(
-            plotms={"xaxis": "chan", "yaxis": "phase"},
-            shadems={"xaxis": "CHAN", "yaxis": "phase"},
-            ragavi_vis={"xaxis": "channel", "yaxis": "phase",
-                        "iter-axis": "scan", "canvas-width": 300,
-                        "canvas-height": 300})
-
-        if plotter.lower() != "none":
-            for plotname in diagnostic_plots:
-                if not pipeline.enable_task(config, plotname):
-                    continue
-                opts = diagnostic_plots[plotname][plotter]
-                if opts is None:
-                    log.warn("The plotter '{0:s}' cannot make the plot '{1:s}'".format(
-                        plotter, plotname))
-                    continue
-                elif plotter == "ragavi_vis":
-                        opts["num-cores"] = config["num_cores"]
-                        opts["mem-limit"] = config["mem_limit"]
-
-                if plotter == "shadems":
-                    # change the labels to indices
-                    with open(msinfo, 'r') as stdr:
-                        corrs = yaml.load(stdr)['CORR']['CORR_TYPE']
-
-                    corr = corr.replace(" ", "").split(",")
-                    for it, co in enumerate(corr):
-                        if co in corrs:
-                            corr[it] = str(corrs.index(co))
-                    corr = ",".join(corr)
-                    # for each corr
-                    for co in corr.split(","):
-                        opts["corr"] = co
-                        for fields_ in specific_fields(plotname) or fields:
-                            for field in getattr(pipeline, fields_)[iobs]:
-                                fid = utils.get_field_id(msinfo, field)[0]
-                                globals()[plotter](pipeline, recipe, config,
-                                                   plotname, msname, field,
-                                                   iobs, label, prefix, opts,
-                                                   ftype=fields_, fid=fid, output_dir=output_dir,
-                                                   corr_label=corrs[int(co)])
-
-                elif plotter == "ragavi_vis" and not opts["iter-axis"] == "corr":
-                    # change the labels to indices
-                    with open(msinfo, 'r') as stdr:
-                        corrs = yaml.load(stdr)['CORR']['CORR_TYPE']
-
-                    corr = corr.replace(" ", "").split(",")
-                    for it, co in enumerate(corr):
-                        if co in corrs:
-                            corr[it] = str(corrs.index(co))
-                    corr = ",".join(corr)
-
-                    # for each corr
-                    for co in corr.split(","):
-                        opts["corr"] = co
-                        for fields_ in specific_fields(plotname) or fields:
-                            for field in getattr(pipeline, fields_)[iobs]:
-                                fid = utils.get_field_id(msinfo, field)[0]
-                                globals()[plotter](pipeline, recipe, config,
-                                                   plotname, msname, field,
-                                                   iobs, label, prefix, opts,
-                                                   ftype=fields_, fid=fid, output_dir=output_dir,
-                                                   corr_label=corrs[int(co)])
+                if plot_args:
+                    step = 'plot-shadems-ms{2:d}'.format(iplot, field_type, iobs)
+                    recipe.add("cab/shadems_direct", step,
+                               dict(ms=msname, args=plot_args,
+                                    ignore_errors=config["shadems"]["ignore_errors"]),
+                               input=pipeline.input, output=output_dir,
+                               label="{0:s}:: Plotting".format(step))
                 else:
-                    opts["corr"] = corr
-                    for fields_ in specific_fields(plotname) or fields:
-                        for field in getattr(pipeline, fields_)[iobs]:
-                            fid = utils.get_field_id(msinfo, field)[0]
-                            globals()[plotter](pipeline, recipe, config,
-                                               plotname, msname, field, iobs, label,
-                                               prefix, opts, ftype=fields_,
-                                               fid=fid, output_dir=output_dir)
+                    log.warning("The shadems section is enabled, but doesn't specify any plot_by_field or plot_by_corr")
+
+            # old-school plots
+
+            # define plot attributes
+            diagnostic_plots = {}
+            diagnostic_plots["real_imag"] = dict(
+                plotms={"xaxis": "imag", "yaxis": "real",
+                        "colouraxis": "baseline", "iteraxis": "corr"},
+                shadems={"xaxis": "real", "yaxis": "imag"},
+                ragavi_vis={"xaxis": "real", "yaxis": "imaginary",
+                            "iter-axis": "scan", "canvas-width": 300,
+                            "canvas-height": 300})
+
+            diagnostic_plots["amp_phase"] = dict(
+                plotms={"xaxis": "amp", "yaxis": "phase",
+                        "colouraxis": "baseline", "iteraxis": "corr"},
+                shadems={"xaxis": "amp", "yaxis": "phase"},
+                ragavi_vis={"xaxis": "phase", "yaxis": "amplitude",
+                            "iter-axis": "corr", "canvas-width": 1080,
+                            "canvas-height": 720})
+
+            diagnostic_plots["amp_ant"] = dict(
+                plotms={"xaxis": "antenna", "yaxis": "amp",
+                        "colouraxis": "baseline", "iteraxis": "corr"},
+                shadems={"xaxis": "ANTENNA1", "yaxis": "amp"},
+                ragavi_vis=None)
+
+            diagnostic_plots["amp_uvwave"] = dict(
+                plotms={"xaxis": "uvwave", "yaxis": "amp",
+                        "colouraxis": "baseline", "iteraxis": "corr"},
+                shadems={"xaxis": "UV", "yaxis": "amp"},
+                ragavi_vis={"xaxis": "uvwave", "yaxis": "amplitude",
+                            "iter-axis": "scan", "canvas-width": 300,
+                            "canvas-height": 300})
+
+            diagnostic_plots["phase_uvwave"] = dict(
+                plotms={"xaxis": "uvwave", "yaxis": "phase",
+                        "colouraxis": "baseline", "iteraxis": "corr"},
+                shadems={"xaxis": "UV", "yaxis": "phase"},
+                ragavi_vis={"xaxis": "uvwave", "yaxis": "phase",
+                            "iter-axis": "scan", "canvas-width": 300,
+                            "canvas-height": 300})
+
+            diagnostic_plots["amp_scan"] = dict(
+                plotms={"xaxis": "scan", "yaxis": "amp"},
+                shadems={"xaxis": "SCAN_NUMBER", "yaxis": "amp"},
+                ragavi_vis={"xaxis": "scan", "yaxis": "amplitude",
+                            "iter-axis": None,
+                            "canvas-width": 1080, "canvas-height": 720})
+
+            diagnostic_plots["amp_chan"] = dict(
+                plotms={"xaxis": "chan", "yaxis": "amp"},
+                shadems={"xaxis": "CHAN", "yaxis": "amp"},
+                ragavi_vis={"xaxis": "channel", "yaxis": "amplitude",
+                            "iter-axis": "scan", "canvas-width": 300,
+                            "canvas-height": 300})
+
+            diagnostic_plots["phase_chan"] = dict(
+                plotms={"xaxis": "chan", "yaxis": "phase"},
+                shadems={"xaxis": "CHAN", "yaxis": "phase"},
+                ragavi_vis={"xaxis": "channel", "yaxis": "phase",
+                            "iter-axis": "scan", "canvas-width": 300,
+                            "canvas-height": 300})
+
+            if plotter.lower() != "none":
+                for plotname in diagnostic_plots:
+                    if not pipeline.enable_task(config, plotname):
+                        continue
+                    opts = diagnostic_plots[plotname][plotter]
+                    if opts is None:
+                        log.warn("The plotter '{0:s}' cannot make the plot '{1:s}'".format(
+                            plotter, plotname))
+                        continue
+                    elif plotter == "ragavi_vis":
+                            opts["num-cores"] = config["num_cores"]
+                            opts["mem-limit"] = config["mem_limit"]
+
+                    if plotter == "shadems":
+                        # change the labels to indices
+                        with open(msinfo, 'r') as stdr:
+                            corrs = yaml.load(stdr)['CORR']['CORR_TYPE']
+
+                        corr = corr.replace(" ", "").split(",")
+                        for it, co in enumerate(corr):
+                            if co in corrs:
+                                corr[it] = str(corrs.index(co))
+                        corr = ",".join(corr)
+                        # for each corr
+                        for co in corr.split(","):
+                            opts["corr"] = co
+                            for fields_ in fields:
+                                for field in getattr(pipeline, fields_)[iobs]:
+                                    fid = utils.get_field_id(msinfo, field)[0]
+                                    globals()[plotter](pipeline, recipe, config,
+                                                       plotname, msname, field,
+                                                       iobs, label, prefix, opts,
+                                                       ftype=fields_, fid=fid, output_dir=output_dir,
+                                                       corr_label=corrs[int(co)])
+
+                    elif plotter == "ragavi_vis" and not opts["iter-axis"] == "corr":
+                        # change the labels to indices
+                        with open(msinfo, 'r') as stdr:
+                            corrs = yaml.load(stdr)['CORR']['CORR_TYPE']
+
+                        corr = corr.replace(" ", "").split(",")
+                        for it, co in enumerate(corr):
+                            if co in corrs:
+                                corr[it] = str(corrs.index(co))
+                        corr = ",".join(corr)
+
+                        # for each corr
+                        for co in corr.split(","):
+                            opts["corr"] = co
+                            for fields_ in fields:
+                                for field in getattr(pipeline, fields_)[iobs]:
+                                    fid = utils.get_field_id(msinfo, field)[0]
+                                    globals()[plotter](pipeline, recipe, config,
+                                                       plotname, msname, field,
+                                                       iobs, label, prefix, opts,
+                                                       ftype=fields_, fid=fid, output_dir=output_dir,
+                                                       corr_label=corrs[int(co)])
+                    else:
+                        opts["corr"] = corr
+                        for fields_ in fields:
+                            for field in getattr(pipeline, fields_)[iobs]:
+                                fid = utils.get_field_id(msinfo, field)[0]
+                                globals()[plotter](pipeline, recipe, config,
+                                                   plotname, msname, field, iobs, label,
+                                                   prefix, opts, ftype=fields_,
+                                                   fid=fid, output_dir=output_dir)

--- a/caracal/workers/inspect_worker.py
+++ b/caracal/workers/inspect_worker.py
@@ -140,15 +140,6 @@ def worker(pipeline, recipe, config):
                 raise ValueError("Eligible values for 'field': 'target', 'calibrators', 'fcal', 'bpcal' or 'gcal'. "\
                                  "User selected: {}".format(field_to_split))
 
-#        if any(x in fields for x in ['fcal','bpcal','gcal']):
-#           calfields = []
-#           for fd in fields:
-#               for elem in getattr(pipeline, fd)[iobs]:
-#                   calfields.append(elem)
-#           field_names = [','.join(np.unique(np.array(calfields))),]
-#        else:
-#           field_names = pipeline.target[iobs]
-
         '''GET LIST OF INPUT MS'''
         mslist = []
         msn = pipeline.msnames[iobs][:-3]
@@ -330,7 +321,11 @@ def worker(pipeline, recipe, config):
                             opts["corr"] = co
                             for fields_ in fields:
                                 for field in getattr(pipeline, fields_)[iobs]:
-                                    fid = utils.get_field_id(msinfo, field)[0]
+                                    if (label_in != '') and (config['field'] == 'target'):
+                                       fid = 0
+                                    else:
+                                        fid = utils.get_field_id(msinfo, field)[0]
+
                                     globals()[plotter](pipeline, recipe, config,
                                                        plotname, msname, field,
                                                        iobs, label, prefix, opts,
@@ -353,7 +348,11 @@ def worker(pipeline, recipe, config):
                             opts["corr"] = co
                             for fields_ in fields:
                                 for field in getattr(pipeline, fields_)[iobs]:
-                                    fid = utils.get_field_id(msinfo, field)[0]
+                                    if (label_in != '') and (config['field'] == 'target'):
+                                        fid = 0
+                                    else:
+                                        fid = utils.get_field_id(msinfo, field)[0]
+
                                     globals()[plotter](pipeline, recipe, config,
                                                        plotname, msname, field,
                                                        iobs, label, prefix, opts,
@@ -363,7 +362,11 @@ def worker(pipeline, recipe, config):
                         opts["corr"] = corr
                         for fields_ in fields:
                             for field in getattr(pipeline, fields_)[iobs]:
-                                fid = utils.get_field_id(msinfo, field)[0]
+                                if (label_in != '') and (config['field'] == 'target'):
+                                    fid = 0
+                                else:
+                                    fid = utils.get_field_id(msinfo, field)[0]
+
                                 globals()[plotter](pipeline, recipe, config,
                                                    plotname, msname, field, iobs, label,
                                                    prefix, opts, ftype=fields_,

--- a/caracal/workers/inspect_worker.py
+++ b/caracal/workers/inspect_worker.py
@@ -138,7 +138,7 @@ def worker(pipeline, recipe, config):
         for fd in fields:
             if fd not in ['target','fcal','bpcal','gcal']:
                 raise ValueError("Eligible values for 'field': 'target', 'calibrators', 'fcal', 'bpcal' or 'gcal'. "\
-                                 "User selected: {}".format(field_to_split))
+                                 "User selected: {}".format(fields))
 
         '''GET LIST OF INPUT MS'''
         mslist = []


### PR DESCRIPTION
Inspect worker has been updated to

- be able inspect target or any calibrator visibilities in the original as well as splitted datasets (issue #1122 ) via setting inspect.field (issue #1096)
- label_cal has been changed to label_plot to make it more intuitive (issue #1103)

I removed individual field selections per plot type. It can only plot targets OR calibrators, requiring repeated inspect worker runs (which however doesn't lead to a significant overhead as per our discussion under issue #1122). Users can also select e.g. field: 'gcal' for plotting specific fields. However, if user selects different intents that belong to the same field (e.g. fcal and bpcal), it will lead to duplicate plots of these fields with different intents as labels in their name (which had been the case before my modifications). So we might want to open a separate issue for this.

I also updated sample config files to have label_plot instead of label_cal, hopefully saving some headache for users updating their caracal 1.0.0 to 1.0.1. I didn't add any extra inspect worker calls to plot target, etc visibilities.

I tested with ragavi and shadems plots. Haven't carate'd it yet though.