### PR TITLE
Some fixes for CARACal v1.0.3

### DIFF
--- a/caracal/sample_configurations/carateConfig.yml
+++ b/caracal/sample_configurations/carateConfig.yml
@@ -214,7 +214,7 @@ selfcal:
   transfer_model:
     enable: true
     num_workers: 12
-    mem_frac: 0.45
+    mem_frac: 0.05
     transfer_to_label: corr
 
 transform__4:

--- a/caracal/schema/selfcal_schema.yml
+++ b/caracal/schema/selfcal_schema.yml
@@ -163,11 +163,11 @@ mapping:
         desc: Scales of multiscale [0,10,20,etc.] in pixels.
         required: false
         example: '0, 5, 10, 20'
-      img_paralldeconv:
-        desc: Speed-up deconvolution by deconvolving subimages in parallel. Subimages will be at most of the size given by this parameter. If set to 0 no parallel deconvolution is performed.
+      img_nrdeconvsubimg:
+        desc: Speed-up deconvolution by splitting the image into a number "img_nrdeconvsubimg" of subimages, which are deconvolved in parallel. If set to 1 no parallel deconvolution is performed. If set to 0 the number of subimages is the same as the number of CPUs used by the selfcal worker (see "ncpu" parameter above).
         type: int
         required: false
-        example: '900'
+        example: '0'
       img_sofia_settings:
         desc: SoFiA source finder settings used for the imaging iterations whose entry in 'image/cleanmask_method' below is 'sofia'. The resulting clean mask is located in <output>/masking.
         type: map

--- a/caracal/schema/selfcal_schema.yml
+++ b/caracal/schema/selfcal_schema.yml
@@ -57,9 +57,9 @@ mapping:
         example: '0'
       ncpu:
         type: int
-        desc: Number of CPUs to use.
+        desc: Number of CPUs to use for distributed processing. If set to 0 all available CPUs are used. This parameter is passed on to the following software in the selfcal worker, WSClean for imaging, Cubical and MeqTrees for calibration, PyBDSF for source finding.
         required: false
-        example: '5'
+        example: '0'
       minuvw_m:
         type: int
         desc: Exclude baselines shorter than this value (given in metres) from the imaging and self-calibration loop.
@@ -153,16 +153,21 @@ mapping:
         required: false
         example: 'I'
       img_multiscale:
-          type: bool
-          desc: Switch on multiscale cleaning.
-          required: false
-          example: 'False'
+        type: bool
+        desc: Switch on multiscale cleaning.
+        required: false
+        example: 'False'
       img_multiscale_scales:
-          seq:
-            - type: int
-          desc: Scales of multiscale [0,10,20,etc.] in pixels.
-          required: false
-          example: '0, 5, 10, 20'
+        seq:
+          - type: int
+        desc: Scales of multiscale [0,10,20,etc.] in pixels.
+        required: false
+        example: '0, 5, 10, 20'
+      img_paralldeconv:
+        desc: Speed-up deconvolution by deconvolving subimages in parallel. Subimages will be at most of the size given by this parameter. If set to 0 no parallel deconvolution is performed.
+        type: int
+        required: false
+        example: '900'
       img_sofia_settings:
         desc: SoFiA source finder settings used for the imaging iterations whose entry in 'image/cleanmask_method' below is 'sofia'. The resulting clean mask is located in <output>/masking.
         type: map

--- a/caracal/schema/selfcal_schema.yml
+++ b/caracal/schema/selfcal_schema.yml
@@ -164,7 +164,7 @@ mapping:
         required: false
         example: '0, 5, 10, 20'
       img_nrdeconvsubimg:
-        desc: Speed-up deconvolution by splitting the image into a number of subimages, which are deconvolved in parallel. This parameter sets the number of subimages as follows. If set to 1 no parallel deconvolution is performed. If set to 0 the number of subimages is the same as the number of CPUs used by the selfcal worker (see "ncpu" parameter above). If set to a number > 1 , the number of subimages is the one requested by the user.
+        desc: Speed-up deconvolution by splitting the image into a number of subimages, which are deconvolved in parallel. This parameter sets the number of subimages as follows. If set to 1 no parallel deconvolution is performed. If set to 0 the number of subimages is the same as the number of CPUs used by the selfcal worker (see "ncpu" parameter above). If set to a number > 1 , the number of subimages is greater than or equal to the one requested by the user.
         type: int
         required: false
         example: '0'

--- a/caracal/schema/selfcal_schema.yml
+++ b/caracal/schema/selfcal_schema.yml
@@ -164,7 +164,7 @@ mapping:
         required: false
         example: '0, 5, 10, 20'
       img_nrdeconvsubimg:
-        desc: Speed-up deconvolution by splitting the image into a number "img_nrdeconvsubimg" of subimages, which are deconvolved in parallel. If set to 1 no parallel deconvolution is performed. If set to 0 the number of subimages is the same as the number of CPUs used by the selfcal worker (see "ncpu" parameter above).
+        desc: Speed-up deconvolution by splitting the image into a number of subimages, which are deconvolved in parallel. This parameter sets the number of subimages as follows. If set to 1 no parallel deconvolution is performed. If set to 0 the number of subimages is the same as the number of CPUs used by the selfcal worker (see "ncpu" parameter above). If set to a number > 1 , the number of subimages is the one requested by the user.
         type: int
         required: false
         example: '0'

--- a/caracal/schema/selfcal_schema.yml
+++ b/caracal/schema/selfcal_schema.yml
@@ -653,7 +653,7 @@ mapping:
             type: float
             desc: Fraction of system RAM that can be used. Used when setting automatically the chunk size.
             required: false
-            example: '0.5'
+            example: '0.05'
       report:
         type: bool
         required: false

--- a/caracal/workers/selfcal_worker.py
+++ b/caracal/workers/selfcal_worker.py
@@ -290,6 +290,12 @@ def worker(pipeline, recipe, config):
     else:
       ncpu = min(ncpu, psutil.cpu_count())
 
+    nrdeconvsubimg = ncpu if config['img_nrdeconvsubimg'] == 0 else config['img_nrdeconvsubimg']
+    if nrdeconvsubimg == 1:
+        wscl_parallel_deconv = None
+    else:
+        wscl_parallel_deconv = np.ceil(config['img_npix']/np.sqrt(nrdeconvsubimg)).astype(int)
+
     mfsprefix = ["", '-MFS'][int(config['img_nchans'] > 1)]
 
     # label of MS where we transform selfcal gaintables
@@ -464,7 +470,7 @@ def worker(pipeline, recipe, config):
             "auto-threshold": config[key]['clean_cutoff'][0],
             "savesourcelist": False,
             "fitbeam": False,
-            "parallel-deconvolution": sdm.dismissable(config['img_paralldeconv']),
+            "parallel-deconvolution": sdm.dismissable(wscl_parallel_deconv),
             "threads": ncpu,
         }
         if maxuvl > 0.:
@@ -531,7 +537,7 @@ def worker(pipeline, recipe, config):
             "fit-spectral-pol": config['img_specfit_nrcoeff'],
             "savesourcelist": True if config['img_niter']>0 else False,
             "auto-threshold": config[key]['clean_cutoff'][num-1 if len(config[key]['clean_cutoff']) >= num else -1],
-            "parallel-deconvolution": sdm.dismissable(config['img_paralldeconv']),
+            "parallel-deconvolution": sdm.dismissable(wscl_parallel_deconv),
             "threads": ncpu,
         }
         if maxuvl > 0.:

--- a/caracal/workers/selfcal_worker.py
+++ b/caracal/workers/selfcal_worker.py
@@ -294,7 +294,7 @@ def worker(pipeline, recipe, config):
     if nrdeconvsubimg == 1:
         wscl_parallel_deconv = None
     else:
-        wscl_parallel_deconv = np.ceil(config['img_npix']/np.sqrt(nrdeconvsubimg)).astype(int)
+        wscl_parallel_deconv = int(np.ceil(config['img_npix']/np.sqrt(nrdeconvsubimg)))
 
     mfsprefix = ["", '-MFS'][int(config['img_nchans'] > 1)]
 

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ requirements = [
     'regions',
     'radiopadre-client>=1.0rc12',
     'jinja2',
+    'psutil',
 ]
 
 PACKAGE_NAME = 'caracal'


### PR DESCRIPTION
Fix #1140 by:
- forcing the regridded mask to be of integer type
- anyway  do not overwrite the user input mask with the regridded one

I've also cleaned up a bit that part of the `selfcal` worker.

Fix #1139 by lowering the default memory fraction to 0.05.