### PR TITLE
Reinstate singularity Jenkins test

### DIFF
--- a/Jenkinsfile.sh
+++ b/Jenkinsfile.sh
@@ -31,10 +31,10 @@ source $WORKSPACE/$BUILD_NUMBER/$PULLFOLDER/caratekit.sh -ws ${caracal_tests} \
                                                          -lc ${caracal_version} \
                                                          -ct ${pull_request_name} \
 							 -dm \
+							 -sm \
                                                          -or \
                                                          -f \
                                                          -op \
-							 -saw \
-							 -um
+							 -spw
 
 rm -rf $TEST_OUTPUT_DIR/$pull_request_name/stimela-singularity

--- a/Jenkinsfile.sh
+++ b/Jenkinsfile.sh
@@ -35,6 +35,4 @@ source $WORKSPACE/$BUILD_NUMBER/$PULLFOLDER/caratekit.sh -ws ${caracal_tests} \
                                                          -or \
                                                          -f \
                                                          -op \
-							 -spw
-
-rm -rf $TEST_OUTPUT_DIR/$pull_request_name/stimela-singularity
+							 -spf $WORKSPACE/singularity_pullfolder

--- a/caratekit.sh
+++ b/caratekit.sh
@@ -2394,7 +2394,7 @@ fi
 # Checking if caratekit has changed
 if [[ -z ${FS} ]]
 then
-    caratekit_install_changes=`diff ${caratekit_install} ${WORKSPACE_ROOT}/caracal/caratekit.sh` || true
+    [[ -z ${caratekit_install} ]] || caratekit_install_changes=`diff ${caratekit_install} ${WORKSPACE_ROOT}/caracal/caratekit.sh` || true
     [[ -z ${caratekit_install_changes} ]] || { \
 					       endimessage+="The installed caratekit.sh:"; endimessage+=$'\n'; \
 					       endimessage+="  ${caratekit_install}"; endimessage+=$'\n'; \


### PR DESCRIPTION
Reinstate Singularity Jenkins test without the need for > v3.5 Singularity. Notice that this will not alter the Singularity cache dir, which may be anywhere.