### PR TITLE
fixes #1112 and cleans up command-line parser, a little

### DIFF
--- a/caracal/dispatch_crew/config_parser.py
+++ b/caracal/dispatch_crew/config_parser.py
@@ -277,7 +277,7 @@ class config_parser(object):
                 if is_list and isinstance(val, list):
                     return [typecast(x) for x in val]
                 if dtype is bool and type(val) is str:
-                    return val in {"true", "yes", "1"}
+                    return val.lower() in {"true", "yes", "1"}
                 return dtype(val)
 
             def value2str(val):
@@ -311,7 +311,8 @@ class config_parser(object):
             else:
                 # for int, float, bool, str
                 dtype = __builtins__[subVars['type']]
-                default_value = subVars["example"]
+                if default_value is None:
+                    default_value = subVars["example"]
 
             # convert default value to expected type
             groups[key] = default_value = typecast(default_value)
@@ -385,6 +386,9 @@ class config_parser(object):
                     #     indent.ljust(60, "-"))
                     _tree_print(v, indent=indent+indent0)
                 else:
+                    # totally ugly -- I promise I'll fix it when we have a better qualifier
+                    if k == "cabs" and not v:
+                        return
                     if type(v) in (list, tuple):
                         vstr = ', '.join([str(x) or '""' for x in v])
                         if len(v) < 2:

--- a/caracal/dispatch_crew/config_parser.py
+++ b/caracal/dispatch_crew/config_parser.py
@@ -1,3 +1,5 @@
+# -*- coding: future_fstrings -*-
+
 import argparse
 import yaml
 import caracal
@@ -248,78 +250,100 @@ class config_parser(object):
         # loop over each key of the variables in the schema
         # the key may contain a set of subkeys, being the schema a nested dictionary
         for key, subVars in sec_defaults.items():
-
             # store the total name of the key given the workerName(base_section) and key (which may be nested)
             # This has '-; for separators
             option_name = base_section + "-" + key if base_section != "" else key
             # corresponding attribute name
             attr_name = option_name.replace("-", "_")
 
-            def typecast(typ, val, string=False):
-                if isinstance(val, list):
-                    return val
-                if typ is bool  and string:
-                    return str(val).lower()
-                elif typ is bool and type(val) is str:
-                    return val in "true yes 1".split()
-                else:
-                    return typ(val)
-
-            # need to go in the nested variable
+            # For subsection, recurse into the nested variable
             if "mapping" in subVars:
-                if key in list(cfgVars.keys()):  # check if enabled in config file
+                if key in cfgVars:  # check if enabled in config file
                     sub_vars = cfgVars[key]
                 else:
-                    sub_vars = dict.fromkeys(list(cfgVars.keys()), {})
-
-                # recall the function with the set of variables of the nest
-                groups[key] = self._process_subparser_tree(sub_vars, subVars, base_section=option_name,
-                                                           options=options)
+                    sub_vars = {key: {} for key in cfgVars.keys()}
+                # recurse with the set of variables of the nest
+                groups[key] = self._process_subparser_tree(sub_vars, subVars, base_section=option_name, options=options)
                 continue
 
-            elif "seq" in subVars:
-                # for lists
+            # True if variable is a list
+            is_list = "seq" in subVars
+            # type of variable (of list element, if dealing with lists)
+            dtype = None
+
+            def typecast(val):
+                """Helper function to cast value to excpected type.
+                If string=True, bools are cast to string bools, so value is suitable for command-line parsing"""
+                if is_list and isinstance(val, list):
+                    return [typecast(x) for x in val]
+                if dtype is bool and type(val) is str:
+                    return val in {"true", "yes", "1"}
+                return dtype(val)
+
+            def value2str(val):
+                """Converts value to string representation. Bools get special lowercase treatment."""
+                return str(bool(val)).lower() if dtype is bool else str(val)
+
+            def str2list(val):
+                """Converts lists in string representation, e.g. "[a, b]" and "a,b", to lists of strings"""
+                return list(val.lstrip("[").rstrip("]").replace(", ",",").split(","))
+
+            # update default if set in user config
+            default_value = None
+            # NB: not sure why the check for _empty() is needed, some archaic carryover
+            if not _empty(list(cfgVars.values())):
+                default_value = cfgVars.get(key)
+
+            # for sequences, do some type fiddling
+            if is_list:
                 dtype = __builtins__[subVars['seq'][0]['type']]
-                if type(subVars["example"]) is not list:
-                    subVars["example"] = list(str.split(subVars['example'].replace(' ', ''), ','))
-                if dtype is bool:
-                    default_value=[]
-                    for i in range(0,len(subVars['example'])):
-                        default_value.append(typecast(dtype, subVars['example'][i],string=False))
-                elif dtype is map:
+                if dtype is map:
                     dtype = dict
-                    default_value = []  # FIX THIS!
-                else:
-                    default_value = list(map(dtype, subVars["example"]))
+                if default_value is None:
+                    if dtype is dict:
+                        default_value = []
+                    else:
+                        default_value = subVars["example"]
+                        if type(default_value) is str:
+                            default_value = str2list(default_value)
+                        if type(default_value) is not list:
+                            raise TypeError(f"{option_name} default value is not configured correctly. This is a bug, please report!")
             else:
                 # for int, float, bool, str
                 dtype = __builtins__[subVars['type']]
                 default_value = subVars["example"]
-                default_value = typecast(dtype, default_value, string=True)
 
-            # update default if set in user config
-            if key in list(cfgVars.keys()) and not _empty(list(cfgVars.values())):
-                default_value = cfgVars[key]
+            # convert default value to expected type
+            groups[key] = default_value = typecast(default_value)
 
+            # if an options object is passed in, look if its value overrides our setting
             if options is not None:
-                option_value = typecast(dtype, getattr(options, attr_name, default_value))
-                if option_value != typecast(dtype, default_value):
-                    caracal.log.info("  command line sets --{} = {}".format(option_name, option_value))
-                groups[key] = option_value
+                if hasattr(options, attr_name):
+                    optval = getattr(options, attr_name)
+                    # parse lists
+                    if is_list:
+                        optval = str2list(optval)
+                    option_value = typecast(optval)
+                    if option_value != default_value:
+                        caracal.log.info("  command line sets --{} = {}".format(option_name, option_value))
+                    groups[key] = option_value
+            # else populate parser with default value
             else:
-                default_value = typecast(dtype, default_value, string=True)
-                if dtype.__name__ == "bool":
+                # lists correspond to multiple arguments
+                if is_list:
+                    # no support for lists of dicts from the command line, for now
+                    if dtype is not dict:
+                        self._parser.add_argument("--" + option_name, help=argparse.SUPPRESS, type=str,
+                                                  default=",".join(map(value2str, default_value)))
+                # booleans have a choice
+                elif dtype is bool:
                     self._parser.add_argument("--" + option_name, help=argparse.SUPPRESS,
-                                              choices="true yes 1 false no 0".split(), default=default_value)
-                elif isinstance(default_value, (list, tuple)):
-                    #parser.add_argument("--" + option_name, help=argparse.SUPPRESS,
-                    #                    type=dtype, nargs="+", default=default_value)
-                    self._parser.add_argument("--" + option_name, help=argparse.SUPPRESS,
-                                             type=dtype, nargs="+", default=list(map(dtype, default_value)))
+                                              choices="true yes 1 false no 0".split(),
+                                              default=value2str(bool(default_value)))
+                # all others passed with native dtype
                 else:
                     self._parser.add_argument("--" + option_name, help=argparse.SUPPRESS,
                                               type=dtype, default=default_value)
-                groups[key] = default_value
 
         return groups
 
@@ -354,14 +378,21 @@ class config_parser(object):
                         extra = {}
                     # (indent == "\t") and caracal.log.info(
                     #     indent.ljust(60, "#"))
-                    caracal.log.info("{}{}:".format(indent, k), extra=extra)
+                    caracal.log.info(f"{indent}{k}:", extra=extra)
                     # (indent == "\t") and caracal.log.info(
                     #     indent.ljust(60, "#"))
                     # (indent != "\t") and caracal.log.info(
                     #     indent.ljust(60, "-"))
                     _tree_print(v, indent=indent+indent0)
                 else:
-                    caracal.log.info("{}{:30}{}".format(indent, k+":", v))
+                    if type(v) in (list, tuple):
+                        vstr = ', '.join([str(x) or '""' for x in v])
+                        if len(v) < 2:
+                            vstr = f"[{vstr}]"
+                    else:
+                        vstr = str(v) or '""'
+                    k += ":"
+                    caracal.log.info(f"{indent}{k:30}{vstr}")
 
             for k, v in other.items():
                 _printval(k, v)

--- a/caracal/workers/worker_administrator.py
+++ b/caracal/workers/worker_administrator.py
@@ -122,17 +122,15 @@ class worker_administrator(object):
         self.skip = []
         # Initialize empty lists for ddids, leave this up to get data worker to define
         self.init_names([])
-        if config["general"]["prep_workspace"]:
-            self.init_pipeline()
+        self.init_pipeline(prep_input=config["general"]["prep_workspace"])
 
         # save configuration file
         configFileName = os.path.splitext(configFileName)[0]
         outConfigName = '{0:s}_{1:s}.yml'.format(
             configFileName, self.timeNow)
 
-        with open(self.configFolder+'/'+outConfigName, 'w') as outfile:
-            ruamel.yaml.dump(self.config, outfile,
-                             Dumper=ruamel.yaml.RoundTripDumper)
+        with open(os.path.join(self.configFolder, outConfigName), 'w') as outfile:
+            ruamel.yaml.dump(self.config, outfile, Dumper=ruamel.yaml.RoundTripDumper)
 
     def init_names(self, dataid):
         """ iniitalize names to be used throughout the pipeline and associated
@@ -251,7 +249,7 @@ class worker_administrator(object):
                 log.info(f"  {name}: using tag {tag} for version {version}")
         return cabspecs
 
-    def init_pipeline(self):
+    def init_pipeline(self, prep_input=True):
         def make_symlink(link, target):
             if os.path.lexists(link):
                 if os.path.islink(link):
@@ -301,16 +299,17 @@ class worker_administrator(object):
                      os.path.join(os.path.basename(self.logs), CARACAL_LOG_BASENAME))
 
         # Copy input data files into pipeline input folder
-        log.info("Copying MeerKAT input files into input folder")
-        datadir = "{0:s}/data/meerkat_files".format(pckgdir)
-        for filename in os.listdir(datadir):
-            src = os.path.join(datadir, filename)
-            dest = os.path.join(self.input, filename)
-            if not os.path.exists(dest):
-                if os.path.isdir(src):
-                    shutil.copytree(src, dest)
-                else:
-                    shutil.copy2(src, dest, follow_symlinks=False)
+        if prep_input:
+            log.info("Copying MeerKAT input files into input folder")
+            datadir = "{0:s}/data/meerkat_files".format(pckgdir)
+            for filename in os.listdir(datadir):
+                src = os.path.join(datadir, filename)
+                dest = os.path.join(self.input, filename)
+                if not os.path.exists(dest):
+                    if os.path.isdir(src):
+                        shutil.copytree(src, dest)
+                    else:
+                        shutil.copy2(src, dest, follow_symlinks=False)
 
         # Copy standard notebooks
         self._init_notebooks = self.config['general']['init_notebooks']


### PR DESCRIPTION
* no more confusing messages (famous last words)

* for list-type variables, support ``--section-variable x,y,z`` on the command line. This is consistent with the yml syntax (the old code needed one to specify ``--section-variable`` multiple times to make a list).