### PR TITLE
Issue 1204

### DIFF
--- a/caracal/schema/crosscal_schema.yml
+++ b/caracal/schema/crosscal_schema.yml
@@ -115,6 +115,11 @@ mapping:
               - type: str
             required: false
             example: "'', '', scan"
+          spw:
+            desc: Only use this subset(s) of the band to compute 'KGF' gains 
+            example: ""
+            required: false 
+            type: str
           b_fillgaps:
             desc: Fill flagged solution channels by interpolation.
             type: int
@@ -214,6 +219,11 @@ mapping:
             type: int
             required: false
             example: "70"
+          spw:
+            desc: Only use this subset(s) of the band to compute 'KGF' gains
+            example: ""
+            required: false 
+            type: str
           plotgains:
             desc: Plot gains with ragavi-gains. The .html plots are located in <output>/diagnostic_plots/crosscal/.
             type: bool

--- a/caracal/workers/crosscal_worker.py
+++ b/caracal/workers/crosscal_worker.py
@@ -135,7 +135,8 @@ def solve(msname, msinfo,  recipe, config, pipeline, iobs, prefix, label, ftype,
         caltable = "%s_%s.%s%d" % (prefix, ftype, term, itern)
         params["caltable"] = caltable + ":output"
         my_term = term
-        if "I" not in order and smodel and term in "KGF":
+        did_I = 'I' in order[:i+1] 
+        if not did_I and smodel and term in "KGF":
             params["smodel"] = ["1", "0", "0", "0"]
         # allow selection of band subset(s) for gaincal see #1204 on github issue tracker
         if term in "KGF":

--- a/caracal/workers/crosscal_worker.py
+++ b/caracal/workers/crosscal_worker.py
@@ -137,6 +137,9 @@ def solve(msname, msinfo,  recipe, config, pipeline, iobs, prefix, label, ftype,
         my_term = term
         if "I" not in order and smodel and term in "KGF":
             params["smodel"] = ["1", "0", "0", "0"]
+        # allow selection of band subset(s) for gaincal see #1204 on github issue tracker
+        if term in "KGF":
+            params["spw"] = config[ftype]["spw"]
 
         if term == "B":
             params["bandtype"] = term


### PR DESCRIPTION
- Fixes #1204
- Fixes #1206 
- Use I,Q,U,v = (1,0,0,0) model when `I` is specified but imaging has not been done
