### PR TITLE
sofia quick fix

### DIFF
--- a/caracal/workers/selfcal_worker.py
+++ b/caracal/workers/selfcal_worker.py
@@ -2144,7 +2144,7 @@ def worker(pipeline, recipe, config):
                 calibrate(target_iter, self_cal_iter_counter, selfcal_products,
                           get_dir_path(image_path, pipeline), mslist, field)
             mask_key=config['image']['cleanmask_method'][self_cal_iter_counter if len(config['image']['cleanmask_method']) > self_cal_iter_counter else -1]
-            if mask_key=='sofia' and self_cal_iter_counter != cal_niter+1:
+            if mask_key=='sofia' and self_cal_iter_counter != cal_niter+1 and pipeline.enable_task(config, 'image'):
                 sofia_mask(target_iter, self_cal_iter_counter, get_dir_path(
                     image_path, pipeline), field)
                 recipe.run()


### PR DESCRIPTION
SoFiA used to run even when imaging and calibration were turned off in the selfcal worker, causing unnecessary overhead when using selfcal worker only to transfer models and gains to a high spectral res ms. Alas no more!