### PR TITLE
Fix indent error

### DIFF
--- a/caracal/workers/prep_worker.py
+++ b/caracal/workers/prep_worker.py
@@ -43,7 +43,7 @@ def getfield_coords(info, field, db, tol=2.9E-3, tol_diff=4.8481E-6):
             else :
                print("Calibrator coordinates match within the specified tolerance.")
                return None, None, None
-        return None, None, None   
+    return None, None, None   
 
 def worker(pipeline, recipe, config):
     label = config['label_in']


### PR DESCRIPTION
A case of the bad indent, which messes up the rephasing to correct calibrator coordinates in the prep worker.
Due to the incorrect indent the loop over calibrators does not run, making the rephasing impossible.
This PR fixes it.