### PR TITLE
Stopgap flagging 

### DIFF
--- a/caracal/sample_configurations/meerkat-continuum-defaults.yml
+++ b/caracal/sample_configurations/meerkat-continuum-defaults.yml
@@ -153,6 +153,8 @@ flag__2:
   enable: true
   field: target
   label_in: corr
+  flag_spw:
+    enable: true
   flag_rfi: 
     enable: true
     col: DATA

--- a/caracal/sample_configurations/meerkat-defaults.yml
+++ b/caracal/sample_configurations/meerkat-defaults.yml
@@ -155,6 +155,8 @@ flag__2:
   enable: true
   field: target
   label_in: corr
+  flag_spw:
+    enable: true
   flag_rfi: 
     enable: true
     col: DATA


### PR DESCRIPTION
Band rolloff does not seem to be flagged by the calflag mode of either applycal or mstransform; resulting in the target data looking like this:

![image (3)](https://user-images.githubusercontent.com/9251962/106940692-8609ab00-672a-11eb-8675-6a598a78d616.png)

While I have no idea why this happens, I am adding a temporary fix by enabling flag_spw in flag__2 for the meerkat configs (which are the only configs to lack it anyway). 