### PR TITLE
user-defined restoring beam for spectral-line cubes

### DIFF
--- a/caracal/schema/line_schema.yml
+++ b/caracal/schema/line_schema.yml
@@ -426,6 +426,13 @@ mapping:
             type: int
             required: false
             example: '0'
+          wscl_beam:
+            desc: Set Bmaj,Bmin,PA of the beam to be used for restoring the clean components. The units are arcsec for Bmaj and Bmin, degrees for PA. Bmaj and Bmin are FWHM. The default values of [0, 0, 0] mean that WSClean chooses the restoring beam based on a 2d Gaussian fit to the dirty beam.
+            type: seq
+            seq:
+              - type: int
+            required: false
+            example: '0, 0, 0'
           casa_thr:
             desc: Flux-density level to stop CASA cleaning. It must include units, e.g. '1.0mJy'.
             type: str

--- a/caracal/workers/line_worker.py
+++ b/caracal/workers/line_worker.py
@@ -790,6 +790,8 @@ def worker(pipeline, recipe, config):
         if config['make_cube']['wscl_multiscale_scales']:
             line_image_opts.update({"multiscale-scales": list(map(int,config['make_cube']['wscl_multiscale_scales'].split(',')))})
 
+        if config['make_cube']['wscl_beam'] != [0, 0, 0]:
+            line_image_opts.update({"beamshape": config['make_cube']['wscl_beam']})
 
         for tt, target in enumerate(all_targets):
             caracal.log.info('Starting to make line cube for target {0:}'.format(target))


### PR DESCRIPTION
Some users are interested in setting the shape of the restoring beam for spectral line cubes. This is already possible  in WSClean so it was just a matter of adding the relevant parameter in the line worker and schema. I've made and tested this change, and it seems to work. @HaoChen-ast please give this a try.