### PR TITLE
flag within a range of u coordinates

### DIFF
--- a/caracal/schema/flag_schema.yml
+++ b/caracal/schema/flag_schema.yml
@@ -117,6 +117,20 @@ mapping:
             enum: ["beg", "endb", "tail", "end"]
             required: False
             example: 'beg'
+      flag_Urange:
+        desc: Flag visibilities within a given range of U values and all V values
+        type: map
+        mapping:
+          enable:
+            desc: Enable the 'flag_URange' segment.
+            type: bool
+            required: False
+            example: 'False'
+          cutoff:
+            desc: Visibilities with abs(U) within cutoff are flagged.
+            type: float
+            required: False
+            example: '1.'
       flag_elevation:
         desc: Use CASA FLAGDATA to flag antennas with pointing elevation outside the selected range.
         type: map


### PR DESCRIPTION
Once binning in channels datacubes show horizontal striping.

<img width="515" alt="Screenshot 2021-11-26 at 17 18 46" src="https://user-images.githubusercontent.com/9263942/143608646-3dab9a93-34be-41d4-b1bc-bf0df6083741.png">

This is similar to what seen by Mario Santos in the power spectrum of MeerKAT's visibilities, and is due to some RFI? at u=0 and over all values of v.

as seen in this FFT the 'striped' datacube


![Screenshot 2021-11-26 at 12 06 55](https://user-images.githubusercontent.com/9263942/143608797-206b4639-a297-4dc4-a25a-01bce12a1caa.jpg)



Hence we add a module that flags (using casacore) in the U coordinate given a certain range.


