### PR TITLE
Scan selection on solvers

### DIFF
--- a/caracal/schema/crosscal_schema.yml
+++ b/caracal/schema/crosscal_schema.yml
@@ -156,6 +156,11 @@ mapping:
             type: int
             required: false
             example: "1"
+          scanselection:
+            desc: String specifying (in CASA format) which scans to select during solving on primary
+            type: str
+            required: false
+            example: "1~5"
           spw_k:
             desc: Only use this subset(s) of the band to compute 'K' gains. Default uses full band 
             example: ""
@@ -265,6 +270,11 @@ mapping:
             type: int
             required: false
             example: "1"
+          scanselection:
+            desc: String specifying (in CASA format) which scans to select during solving on secondary
+            type: str
+            required: false
+            example: "1~5"
           spw_k:
             desc: Only use this subset(s) of the band to compute 'K' gains. Default uses full band 
             example: ""

--- a/caracal/workers/crosscal_worker.py
+++ b/caracal/workers/crosscal_worker.py
@@ -174,15 +174,19 @@ def solve(msname, msinfo, recipe, config, pipeline, iobs, prefix, label, ftype,
         # allow selection of band subset(s) for gaincal see #1204 on github issue tracker
         if term in "GF":
             params["spw"] = config[ftype]["spw_g"]
+            params["scan"] = config[ftype]["scanselection"]
         elif term == "K":
             params["spw"] = config[ftype]["spw_k"]
+            params["scan"] = config[ftype]["scanselection"]
         if term == "B":
             params["bandtype"] = term
             params["solnorm"] = config[ftype]["b_solnorm"]
             params["fillgaps"] = config[ftype]["b_fillgaps"]
             params["uvrange"] = config["uvrange"]
+            params["scan"] = config[ftype]["scanselection"]
         elif term == "K":
             params["gaintype"] = term
+            params["scan"] = config[ftype]["scanselection"]
         elif term in "FG":
             my_term = ["F", "G"]
             if term == "F":
@@ -194,7 +198,8 @@ def solve(msname, msinfo, recipe, config, pipeline, iobs, prefix, label, ftype,
                 params["append"] = True
                 caltable = "%s_%s.F%d" % (prefix, ftype, itern)
                 params["caltable"] = primary_G + ":output"
-
+            else:
+                params["scan"] = config[ftype]["scanselection"]
             params["gaintype"] = "G"
             params["uvrange"] = config["uvrange"]
             params["calmode"] = first_if_single(config[ftype]["calmode"], i).strip("'")


### PR DESCRIPTION
Fixes #1391 (workaround for SPR1-1177 - mislabelling of tracking scans in katdal). This adds the ability to deselect scans
when solving (note not necessarily applying - user should still flag those scans). It is however essential to flag them to avoid interpolated solution being flagged and unnecessarily flagging transfer scans

@Sinah-astro please use this branch for now