### PR TITLE
Fix small bug in line mask regridding

### DIFF
--- a/caracal/workers/line_worker.py
+++ b/caracal/workers/line_worker.py
@@ -924,7 +924,7 @@ def worker(pipeline, recipe, config):
                                             toAdd = np.zeros([hdul[0].header['NAXIS3'],hdul[0].data.shape[1],delt])
                                         else: toAdd = np.zeros([hdul[0].header['NAXIS3'],delt,hdul[0].data.shape[2]])
                                         hdul[0].data = np.concatenate([toAdd,hdul[0].data],axis=axDict[i][0])
-                                        hdul[0].header['CRPIX'+i] = int(cent + delt)
+                                        hdul[0].header['CRPIX'+i] = cent + delt
                                     if hdul[0].data.shape[axDict[i][0]] < axDict[i][1]:
                                         delt = int(axDict[i][1] - hdul[0].data.shape[axDict[i][0]])
                                         if i == '1':


### PR DESCRIPTION
@dane-kleiner and I spotted this possible error. The `int()` call results in a mask regridded by Montage to a header with CRPIX2 = 600.5 being modified to CRPIX2 = 601 after adding a single Y layer. In fact, it should have been modified to CRPIX2 = 601.5. This bug results in a small but noticeable WCS offset.

Note that this only happens when the regridded mask needs to be added X or Y layers (which is the case sometimes, although I don't remember why...)

@molnard89 please check that this fix is correct.