### PR TITLE
fix issue 1209

### DIFF
--- a/caracal/workers/line_worker.py
+++ b/caracal/workers/line_worker.py
@@ -63,9 +63,11 @@ def freq_to_vel(filename, reverse):
                 # https://fits.gsfc.nasa.gov/standard40/fits_standard40aa-le.pdf
 
                 headcube['ctype3'] = 'VRAD'
-                if 'cunit3' in headcube:
-                    # delete cunit3 because we adopt the default units = m/s
-                    del headcube['cunit3']
+                headcube['cunit3'] = 'm/s'
+                # 3 lines below commented out because of issue 1209
+                #if 'cunit3' in headcube:
+                #    # delete cunit3 because we adopt the default units = m/s
+                #    del headcube['cunit3']
 
             # convert from radio velocity to frequency
             elif (headcube['naxis'] > 2) and ('VRAD' in headcube['ctype3']) and (headcube['naxis'] > 2) and reverse:
@@ -73,9 +75,11 @@ def freq_to_vel(filename, reverse):
                 headcube['crval3'] = restfreq * \
                     (1 - float(headcube['crval3']) / C)
                 headcube['ctype3'] = 'FREQ'
-                if 'cunit3' in headcube:
-                    # delete cunit3 because we adopt the default units = Hz
-                    del headcube['cunit3']
+                headcube['cunit3'] = 'Hz'
+                # 3 lines below commented out because of issue 1209
+                #if 'cunit3' in headcube:
+                #    # delete cunit3 because we adopt the default units = Hz
+                #    del headcube['cunit3']
             else:
                 if not reverse:
                     caracal.log.warn(


### PR DESCRIPTION
As discussed in #1209  , even though there are default units, the FITS standard document recommends explicitly stating the units in the header. This PR does that.

The cubes made by WSclean are in frequency and have CUNIT3 = Hz in the header. When converting to velocity CARACal deletes CUNIT3. This PR changes that behaviour, and changes CUNIT3 from Hz to m/s when converting the axis. If the reverse conversion is requested, CUNIT3 changes from m/s to Hz.