### PR TITLE
fix #1589

### DIFF
--- a/caracal/workers/line_worker.py
+++ b/caracal/workers/line_worker.py
@@ -922,7 +922,7 @@ def worker(pipeline, recipe, config):
                         C = 2.99792458e+8  # m/s
                         femit = [r.strip() for r in re.split('([-+]?\d+\.\d+)|([-+]?\d+)', restfreq.strip()) if r is not None and r.strip() != '']
                         femit = (eval(femit[0]) * units.Unit(femit[1])).to(units.Hz).value  # Hz
-                        t = summary_file if config['make_cube']['use_mstransform'] else summary_file.replace('_mst', '')
+                        t = mslist[0].replace('.ms', '-summary.json') # first file given to WSClean as input
                         with open('{}/{}'.format(pipeline.msdir, t)) as f:
                             obsDict = json.load(f)
                         raTarget = np.round(obsDict['FIELD']['REFERENCE_DIR'][0][0][0] / np.pi * 180, 5)
@@ -941,7 +941,7 @@ def worker(pipeline, recipe, config):
                         caracal.log.info('CubeHeight (px) = {}'.format(cubeHeight))
                         caracal.log.info('CubeWidht (px) = {}'.format(cubeWidth))
 
-                        postGridMask = preGridMask.replace('.fits', '_{}_regrid.fits'.format(pipeline.prefix))
+                        postGridMask = preGridMask.replace('.fits', '_{}_{}_regrid.fits'.format(pipeline.prefix, target))
 
                         with fits.open('{}/{}'.format(pipeline.masking, preGridMask)) as hdul:
 


### PR DESCRIPTION
Fix #1589 by taking the central RA,Dec of the cube (used for regridding the user mask) from the correct `obsinfo.json` file.

I've also changed the name of the regridded mask FITS, such that it includes the name of the target. This avoids that the regridded mask is overwritten at every iteration when looping over N targets.