### PR TITLE
sofia2 in the line worker

### DIFF
--- a/caracal/schema/line_schema.yml
+++ b/caracal/schema/line_schema.yml
@@ -363,7 +363,7 @@ mapping:
             example: '13.5'
 
       make_cube:
-        desc: Make a line cube using either WSClean + SoFiA (optional for clean masks) or CASA Clean.
+        desc: Make a line cube using either WSClean + SoFiA-2 (optional for clean masks) or CASA Clean.
         type: map
         mapping:
           enable:
@@ -372,7 +372,7 @@ mapping:
             required: false
             example: 'false'
           image_with:
-            desc: Choose whether to image with WSClean + SoFiA ('wsclean') or with CASA Clean ('casa').
+            desc: Choose whether to image with WSClean + SoFiA-2 ('wsclean') or with CASA Clean ('casa').
             type: str
             enum: ['wsclean', 'casa']
             required: false
@@ -461,22 +461,22 @@ mapping:
             required: false
             example: '1.0'
           wscl_sofia_niter:
-            desc: Maximum number of WSClean + SoFiA iterations. The initial cleaning is done with WSClean automasking or with a user-provided clean mask. Subsequent iterations use a SoFiA clean mask. A value of 1 means that WSClean is only executed once and SoFiA is not used. The value of this parameter must be >= 1. Values < 1 will be ignored, and a value of 1 will be used instead.
+            desc: Maximum number of WSClean + SoFiA-2 iterations. The initial cleaning is done with WSClean automasking or with a user-provided clean mask. Subsequent iterations use a SoFiA-2 clean mask. A value of 1 means that WSClean is only executed once and SoFiA-2 is not used. The value of this parameter must be >= 1. Values < 1 will be ignored, and a value of 1 will be used instead.
             type: int
             required: false
             example: '2'
           wscl_sofia_converge:
-            desc: Stop the WSClean + SoFiA iterations if the cube RMS has dropped by a factor < wscl_sofia_converge when comparing the last two iterations (considering only channels that were cleaned). If set to 0 then the maximum number of iterations is performed regardless of the change in RMS.
+            desc: Stop the WSClean + SoFiA-2 iterations if the cube RMS has dropped by a factor < wscl_sofia_converge when comparing the last two iterations (considering only channels that were cleaned). If set to 0 then the maximum number of iterations is performed regardless of the change in RMS.
             type: float
             required: false
             example: '1.1'
           wscl_removeintermediate:
-            desc: If set to true, WSClean + SoFiA intermediate-cubes are deleted from the output directory. If set to false, WSClean + SoFiA intermediate-cubes are retained in the output directory.
+            desc: If set to true, WSClean + SoFiA-2 intermediate-cubes are deleted from the output directory. If set to false, WSClean + SoFiA-2 intermediate-cubes are retained in the output directory.
             type: bool
             required: false
             example: 'False'
           wscl_user_clean_mask:
-            desc: User-provided WSClean clean-mask for the first WSClean + SoFiA iteration (i.e. give the filename of the clean-mask, which is to be located in the output/masking folder).
+            desc: User-provided WSClean clean-mask for the first WSClean + SoFiA-2 iteration (i.e. give the filename of the clean-mask, which is to be located in the output/masking folder).
             type: str
             required: false
             example: ''
@@ -667,92 +667,295 @@ mapping:
             type: bool
             required: false
             example: 'False'
-            
-      sofia:
-        desc: Run SoFiA source-finder on the final HI cubes to produce a detection mask, moment images and catalogues. Note that these settings are not used to make clean masks.
+
+      do_sourcefinding:
+        desc: Use sofia2 to do source finding. Settings taken from sofia2_settings. The output products are placed in the sofia directory in the same directory as the input image.
+        type: bool
+        required: false
+        example: 'False'
+
+      sofia2_settings:
+        desc: Settings to be used in the making of a clean_mask and / or source finding for moment maps and HI characterisation. 
         type: map
         mapping:
-          enable:
-            desc: Enable the 'sofia' segment.
-            type: bool
-            required: false
-            example: 'False'
           imcontsub:
             desc: Use results of imcontsub instead of image cubes if available
             type: bool
             required: false
             example: 'False'
-          flag:
-            desc: Use flag regions?
-            type: bool
+          input_mask:
+            desc: Name of input mask cube. Needs to be located in the same directory as the input cube i.e. output/cubes/cube_<n>.
+            type: str
             required: false
-            example: 'False'
-          flagregion:
-            desc: Pixel/channel range(s) to be flagged prior to source finding. Format is [[x1, x2, y1, y2, z1, z2], ...].
+            example: ''
+          input_noise:
+            desc: Name of input noise cube. Needs to be located in the same directory as the input cube i.e. output/cubes/cube_<n>.
+            type: str
+            required: false
+            example: ''
+          input_weights:
+            desc: Name of input weights cube. Needs to be located in the same directory as the input cube i.e. output/cubes/cube_<n>.
+            type: str
+            required: false
+            example: ''
+          flag_auto:
+            desc: SoFiA-2 will attempt to automatically flag spectral channels and spatial pixels affected by interference or artefacts based on their RMS noise level. If set to channels, only spectral channels will be flagged. If set to pixels, only spatial pixels will be flagged.
+            type: str
+            enum: ['true', 'false', 'channels', 'pixels']
+            required: false
+            example: 'false'
+          flag_catalog:
+            desc: Name of catalogue file containing two columns that specify the longitude and latitude coordinates of sky positions to be flagged in the native coordinate system and units of the input data cube. The two columns can be separated by spaces, tabulators or commas.  Needs to be located in <>.
+            type: str
+            required: false
+            example: ''
+          flag_radius:
+            desc: Radius around the sky positions listed in the catalogue provided by flag_catalog that should be flagged. If 0, then only the nearest pixel to the position will be flagged. Otherwise, pixels within the specified radius around the nearest pixel will be flagged.
+            type: int
+            required: false
+            example: '5'
+          flag_region:
+            desc: Region(s) to be flagged in the input data cube prior to processing. The flagging region must contain a multiple of six comma-separated integer values of the following format; x_min, x_max, y_min, y_max, z_min, z_max, ... (all in units of pixels and 0-based). Pixels within those regions will be set to blank in the input cube.
             seq:
               - type: int
             required: false
             example: '0, 0, 0, 0, 0, 0'
-          rmsMode:
-            desc: Method to determine rms ('mad' for using median absolute deviation, 'std' for using standard deviation, 'negative' for using Gaussian fit to negative voxels).
-            type: str
-            required: false
-            example: 'mad'
-          thr:
-            desc: SoFiA source-finding threshold, in terms of the number of sigma_rms to go down to (i.e. the minimum signal-to-noise ratio).
+          flag_threshold:
+            desc: Relative threshold in multiples of the standard deviation to be applied by the automatic flagging algorithm. Only relevant if flag_auto is enabled.
             type: float
             required: false
-            example: '4.0'
-          merge:
-            desc: Merge pixels detected by any of the SoFiA source-finding algorithms into objects. If enabled, pixels with a separation of less than mergeX pixels in the X direction, mergeY pixels in the Y direction, and mergeZ channels in the Z direction will be merged and identified as a single object in the mask. Objects whose extent is smaller than minSizeX, minSizeY or minSizeZ will be removed from the mask.
+            example: '5.0'
+          scaleNoise:
+            desc: the noise scaling modules is to measure the noise level in the input cube and then divide the input cube by the noise. This can be used to correct for spatial or spectral noise variations across the input cube prior to running the source finder.
+            type: map
+            mapping:
+              enable:
+                desc: Enable the noise scaling section.
+                type: bool
+                required: false
+                example: 'True'
+              fluxRange:
+                desc: Flux range to be used in the noise measurement. If set to negative or positive, only pixels with negative or positive flux will be used, respectively. This can be useful to prevent real emission or artefacts from affecting the noise measurement. If set to full, all pixels will be used in the noise measurement irrespective of their flux.
+                type: str
+                enum: ['positive', 'negative', 'full']
+                required: false
+                example: 'negative'
+              interpolate:
+                desc: If set to true, linear interpolation will be used to interpolate the measured local noise values in between grid points. If set to false, the entire grid cell will instead be filled with the measured noise value.
+                type: bool
+                required: false
+                example: 'False'
+              mode:
+                desc: If set to spectral, the noise level will be determined for each spectral channel by measuring the noise within each image plane. This is useful for data cubes where the noise varies with frequency. If set to local, the noise level will be measured locally in window running across the entire cube in all three dimensions. This is useful for data cubes with more complex noise variations, such as interferometric images with primary-beam correction applied.
+                type: str
+                enum: ['spectral', 'local']
+                required: false
+                example: 'spectral'
+              scfind:
+                desc: If true and global or local noise scaling is enabled, then noise scaling will additionally be applied after each smoothing operation in the S+C finder. This might be useful in certain situations where large-scale artefacts are present in interferometric data. However, this feature should be used with great caution, as it has the potential to do more harm than good.
+                type: bool
+                required: false 
+                example: 'False'
+              statistic:
+                desc: Standard deviation, median absolute deviation and Gaussian fitting to the flux histogram, respectively. Standard deviation is by far the fastest algorithm, but it is also the least robust one with respect to emission and artefacts in the data. Median absolute deviation and Gaussian fitting are far more robust in the presence of strong, extended emission or artefacts, but will usually take longer.
+                type: str
+                enum: ['std', 'mad', 'gauss']
+                required: false 
+                example: 'mad'
+              windowXY:
+                desc: Standard deviation, median absolute deviation and Gaussian fitting to the flux histogram, respectively. Standard deviation is by far the fastest algorithm, but it is also the least robust one with respect to emission and artefacts in the data. Median absolute deviation and Gaussian fitting are far more robust in the presence of strong, extended emission or artefacts, but will usually take longer.
+                type: int
+                required: false 
+                example: '25'
+              windowZ:
+                desc: Standard deviation, median absolute deviation and Gaussian fitting to the flux histogram, respectively. Standard deviation is by far the fastest algorithm, but it is also the least robust one with respect to emission and artefacts in the data. Median absolute deviation and Gaussian fitting are far more robust in the presence of strong, extended emission or artefacts, but will usually take longer.
+                type: int
+                required: false 
+                example: '15'
+          scfind:
+            desc: The S+C finder operates by iteratively smoothing the data cube with a user-defined set of smoothing kernels, measuring the noise level on each smoothing scale, and adding all pixels with an absolute flux above a user-defined relative threshold to the source detection mask. 
+            type: map
+            mapping:
+              enable:
+                desc: Enable the Smooth + Clip (S+C) finder section.
+                type: bool
+                required: false
+                example: 'True'
+              fluxRange:
+                desc: Flux range to be used in the noise measurement. If set to negative or positive, only pixels with negative or positive flux will be used, respectively. This can be useful to prevent real emission or artefacts from affecting the noise measurement. If set to full, all pixels will be used in the noise measurement irrespective of their flux.
+                type: str
+                enum: ['positive', 'negative', 'full']
+                required: false
+                example: 'negative'
+              kernelsXY:
+                desc: Comma-separated list of spatial Gaussian kernel sizes to apply. The individual kernel sizes must be floating-point values and denote the full width at half maximum (FWHM) of the Gaussian used to smooth the data in the spatial domain. A value of 0 means that no spatial smoothing will be applied.
+                seq:
+                  - type: int
+                required: false
+                example: '[0, 3, 6]'
+              kernelsZ:
+                desc: Comma-separated list of spectral Boxcar kernel sizes to apply. The individual kernel sizes must be odd integer values of 3 or greater and denote the full width of the Boxcar filter used to smooth the data in the spectral domain. A value of 0 means that no spectral smoothing will be applied.
+                seq:
+                  - type: int
+                required: false
+                example: '[0, 3, 7, 15]'
+              statistic:
+                desc: Standard deviation, median absolute deviation and Gaussian fitting to the flux histogram, respectively. Standard deviation is by far the fastest algorithm, but it is also the least robust one with respect to emission and artefacts in the data. Median absolute deviation and Gaussian fitting are far more robust in the presence of strong, extended emission or artefacts, but will usually take longer.
+                type: str
+                enum: ['std', 'mad', 'gauss']
+                required: false 
+                example: 'mad'
+              threshold:
+                desc: Flux threshold to be used by the S+C finder relative to the measured noise level in each smoothing iteration. In practice, values in the range of about 3 to 5 have proven to be useful in most situations, with lower values in that range requiring use of the reliability filter to reduce the number of false detections.
+                type: float
+                required: false 
+                example: '4.0'
+          linker:
+            desc: The linker will be run to merge the pixels detected by the source finder into coherent detections that can then be parameterised and catalogued. If false, the pipeline will be terminated after source finding, and no catalogue or source products will be created. Disabling the linker can be useful if only the raw mask from the source finder is needed.
+            type: map
+            mapping:
+              enable:
+                desc: Enable the linker section.
+                type: bool
+                required: false
+                example: 'True'
+              maxSizeXY:
+                desc: Maximum size of sources in the spatial dimension in pixels. Sources that exceed this limit will be discarded by the linker. If the value is set to 0, maximum size filtering will be disabled.
+                type: int
+                required: false
+                example: '0'
+              maxSizeZ:
+                desc: Maximum size of sources in the spectral dimension in pixels. Sources that exceed this limit will be discarded by the linker. If the value is set to 0, maximum size filtering will be disabled.
+                type: int
+                required: false
+                example: '0'
+              minSizeXY:
+                desc: Minimum size of sources in the spatial dimension in pixels. Sources that fall below this limit will be discarded by the linker.
+                type: int
+                required: false
+                example: '2'
+              minSizeZ:
+                desc: Minimum size of sources in the spectral dimension in pixels. Sources that fall below this limit will be discarded by the linker.
+                type: int
+                required: false
+                example: '2'
+              radiusXY:
+                desc: Maximum merging length in the spatial dimension. Pixels with a separation of up to this value will be merged into the same source.
+                type: int
+                required: false
+                example: '3'
+              radiusZ:
+                desc: Maximum merging length in the spectral dimension. Pixels with a separation of up to this value will be merged into the same source.
+                type: int
+                required: false
+                example: '3'
+          reliability:
+            desc: Determine the reliability of each detection with positive total flux by comparing the density of positive and negative detections in a three-dimensional parameter space. Sources below the specified reliability threshold will then be discarded. Note that this will require a sufficient number of negative detections, which can usually be achieved by setting the source finding threshold to somewhere around 3 to 4 times the noise level.
+            type: map
+            mapping:
+              enable:
+                desc: Enable the reliability section.
+                type: bool
+                required: false
+                example: 'False'
+              minPixels:
+                desc: Minimum total number of spatial and spectral pixels within the source mask for detections to be considered reliable. The reliability of any detection with fewer pixels will be set to zero by default.
+                type: int
+                required: false
+                example: '0'
+              minSNR:
+                desc: Lower signal-to-noise limit for reliable sources. Detections that fall below this threshold will be deemed unreliable and assigned a reliability of 0.
+                type: float
+                required: false
+                example: '3.0'
+              plot:
+                desc: Diagnostic plots (in EPS format) will be created to allow the quality of the reliability estimation to be assessed. It is advisable to generate and inspect these plots to ensure that the outcome of the reliability filtering procedure is satisfactory.
+                type: bool
+                required: false
+                example: 'True'
+              scaleKernel:
+                desc: When estimating the density of positive and negative detections in parameter space, the size of the Gaussian kernel used in this process is determined from the covariance of the distribution of negative detections in parameter space. This parameter setting can be used to scale that kernel by a constant factor.
+                type: float
+                required: false
+                example: '0.4'
+              autoKernel:
+                desc: If set to true, SoFiA-2 will try to automatically determine the optimal reliability kernel scale factor. If the algorithm fails to converge, then the default value of scaleKernel will be used instead.
+                type: bool
+                required: false
+                example: 'False'
+              threshold:
+                desc: Reliability threshold in the range of 0 to 1. Sources with a reliability below this threshold will be discarded.
+                type: float
+                required: false
+                example: '0.9'
+          dilation:
+            desc: Source mask dilation whereby the mask of each source will be grown outwards until the resulting increase in integrated flux drops below a given threshold or the maximum number of iterations is reached.
+            type: map
+            mapping:
+              enable:
+                desc: Enable the dilation section.
+                type: bool
+                required: false
+                example: 'False'
+              iterationsXY:
+                desc: Sets the maximum number of spatial iterations for the mask dilation algorithm. Once this number of iterations has been reached, mask dilation in the spatial plane will stop even if the flux increase still exceeds the threshold set by threshold.
+                type: int
+                required: false
+                example: '10'
+              iterationsZ:
+                desc: Sets the maximum number of spectral iterations for the mask dilation algorithm. Once this number of iterations has been reached, mask dilation in the spatial plane will stop even if the flux increase still exceeds the threshold set by threshold.
+                type: int
+                required: false
+                example: '5'
+              threshold:
+                desc: If a positive value is provided, mask dilation will end when the increment in the integrated flux during a single iteration drops below this value times the total integrated flux (from the previous iteration), or when the maximum number of iterations has been reached. Specifying a negative threshold will disable flux checking altogether and always carry out the maximum number of iterations.
+                type: float
+                required: false
+                example: '0.001'
+          parameter:
+            desc: The parametrisation module will be enabled to measure the basic phyiscal parameters of each detected source.
+            type: map
+            mapping:
+              enable:
+                desc: Enable the parametrisation section.
+                type: bool
+                required: false
+                example: 'False'
+          output_writeCubelets:
+            desc: Create individual source products for each detected source, including sub-cubes, masks, moment maps and integrated spectra. The source products will be written to a sub-directory with the suffix _cubelets. Each source product will be labelled with the source ID number for identification.
             type: bool
             required: false
             example: 'False'
-          mergeX:
-            desc: Merging radius (in pixels) in the X direction (RA axis).
-            type: int
+          output_thresholdMom12:
+            desc: Create the moment 1 and 2 maps for each individual detection will be created using only those spectral channels where the flux density exceeds this value times the local RMS noise level. E.g., setting output.thresholdMom12 to a value of 3.0 would set a 3-sigma flux density threshold for moments 1 and 2. Note that this setting has no effect on moment 0 maps or global moment 1 and 2 maps.
+            type: float
             required: false
-            example: '2'
-          mergeY:
-            desc: Merging radius (in pixels) in the Y direction (Dec axis).
-            type: int
-            required: false
-            example: '2'
-          mergeZ:
-            desc: Merging radius (in channels) in Z direction (spectral axis).
-            type: int
-            required: false
-            example: '3'
-          minSizeX:
-            desc: Minimum size (in pixels) in the X direction (RA axis).
-            type: int
-            required: false
-            example: '3'
-          minSizeY:
-            desc: Minimum size (in pixels) in the Y direction (Dec axis).
-            type: int
-            required: false
-            example: '3'
-          minSizeZ:
-            desc: Minimum size (in channels) in the Z direction (spectral axis).
-            type: int
-            required: false
-            example: '3'
-          cubelets:
-            desc: Create a cubelet for each detected emission-line object.
+            example: '0.0'
+          output_writeCatASCII:
+            desc: Create a source catalogue will be produced in human-readable ASCII format. The catalogue file will have the suffix _cat.txt.
             type: bool
             required: false
-            example: 'True'
-          mom0:
-            desc: Create a moment-0 image of the field.
+            example: 'False'
+          output_writeCatXML:
+            desc: Create a source catalogue will be produced in VO-compatible XML format. The catalogue file will have the suffix _cat.xml.
             type: bool
             required: false
-            example: 'True'
-          mom1:
-            desc: Create a moment-1 image of the field.
+            example: 'False'
+          output_writeRawMask:
+            desc: Create a data cube containing the raw, binary source mask produced by the source finder prior to linking will be written in FITS format. The raw mask cube will have the suffix _mask-raw.fits.
             type: bool
             required: false
-            example: 'True'
+            example: 'False'
+          output_writeMask2d:
+            desc: Create an image containing a two-dimensional projection of the 3D mask cube will be written in FITS format. The 2D mask image will have the suffix _mask-2d.fits. Note that some sources may be hidden behind others in this 2D projection.
+            type: bool
+            required: false
+            example: 'False'
+          output_writeMoments:
+            desc: Create images of the spectral moments 0, 1 and 2 and the number of channels in each pixel of the moment 0 map will be written in FITS format. The maps will have the suffix _mom0.fits, _mom1.fits, _mom2.fits and _chan.fits. Note that moments 1 and 2 and the number of channels will not be produced if the input data cube is only two-dimensional.
+            type: bool
+            required: false
+            example: 'False'
 
       sharpener:
         desc: Run sharpener to extract and plot the spectra of all continuum sources brighter than a given threshold.


### PR DESCRIPTION
Sofia-2 with many more options to replace sofia. 

The current set up is that any sofia-2 input file (e.g. own mask, flagging catalogue) needs. to be in the same directory as the input cube. This can be changed, I'm not sure it makes it better -- happy to discuss. If using Sofia-2 for making a clean mask with wscl + sofia, the output of the source finding is put in the output directory of the cube it was run on. If do_sourcefinding is true, then the outputs are put into its own sofia directory where the input cube is. 