### PR TITLE
Make casa clean work again

### DIFF
--- a/caracal/workers/line_worker.py
+++ b/caracal/workers/line_worker.py
@@ -1809,7 +1809,7 @@ def worker(pipeline, recipe, config):
                 image_opts.update(
                     {
                         "uvtaper": True,
-                        "outertaper": config["make_cube"]["taper"],
+                        "outertaper": str(config["make_cube"]["taper"]),
                     }
                 )
             recipe.add(


### PR DESCRIPTION
Sets the outertaper to string when given to casa.
See issue #1674 for details.