### PR TITLE
Log warning if schema version mismatch whenever the validation fails.

### DIFF
--- a/caracal/dispatch_crew/config_parser.py
+++ b/caracal/dispatch_crew/config_parser.py
@@ -180,6 +180,14 @@ class config_parser(object):
                     errs.append(message)
 
         if errors:
+            # Also re-log the warning about the schema version,
+            # if it's not the same as the one CARACal is running with.
+            if version != caracal.schema.SCHEMA_VERSION:
+                caracal.log.warning(
+                    "Configuration file schema version is {}, but CARACal is running with schema version {}. This may cause problems.".format(
+                        version, caracal.schema.SCHEMA_VERSION
+                    )
+                )
             raise ConfigErrors(config_file, errors)
 
         return validated_content, version

--- a/caracal/main.py
+++ b/caracal/main.py
@@ -199,7 +199,7 @@ def main(argv):
             parser = config_parser.config_parser()
             _, version = parser.validate_config(sample_config_path)
             if version != SCHEMA_VERSION:
-                log.warning(f"Sample config file {sample_config} version is {SCHEMA_VERSION}, current CARACal version is {{version}}.")
+                log.warning(f"Sample config file {sample_config} version is {version}, current CARACal version is {SCHEMA_VERSION}.")
                 log.warning("Proceeding anyway, but please notify the CARACal team to ship a newer sample config!")
         except config_parser.ConfigErrors as exc:
             log.error(f"{exc}, list of errors follows:")

--- a/caracal/sample_configurations/meerkat-polcal-strategies.yml
+++ b/caracal/sample_configurations/meerkat-polcal-strategies.yml
@@ -71,7 +71,8 @@ polcal:
   reuse_existing_tables: false
   pol_calib: xcal
   leakage_calib: fcal
-  set_model_pol: true
+  set_model_pol:
+    enable: true
   gain_solint: '60s'
   time_solint: 'inf'
   plotgains: true


### PR DESCRIPTION
Now `caracal` will print the warning again before raising and exception:

```python
(caracalcal) ramaila@stills:~/working/testing/caracal$ caracal -c gps-test.yml -ew obsconf
2026-06-23 15:54:48 CARACal INFO: Invoked as /home/ramaila/.virtualenvs/caracalcal/bin/caracal -c gps-test.yml -ew obsconf
2026-06-23 15:54:51 CARACal WARNING: Configuration file schema version is 1.1.0, but CARACal is running with schema version 1.2.0. This may cause problems.
2026-06-23 15:54:51 CARACal ERROR: configuration file gps-test.yml fails to validate, list of errors follows:
obsconf:
- Value 'True' is not a dict. Value path: '/obsconf/obsinfo'

```