### PR TITLE
Restore FFT image in flag_u_zeros right-panel plot

### DIFF
--- a/caracal/workers/utils/flag_Uzeros.py
+++ b/caracal/workers/utils/flag_Uzeros.py
@@ -377,6 +377,13 @@ class UzeroFlagger:
         extent = [-w * udelt, w * udelt, -w * vdelt, w * vdelt]
         if common_vmax == 0:
             common_vmax = np.nanpercentile(inFFTData[cx - w : cx + w + 1, cy - w : cy + w + 1], 99)
+        ax2.imshow(
+            inFFTData[cx - w : cx + w + 1, cy - w : cy + w + 1],
+            vmin=0,
+            vmax=common_vmax,
+            extent=extent,
+            origin="upper",
+        )
         if ctff:
             ax2.contour(
                 inFFTData[cx - w : cx + w + 1, cy - w : cy + w + 1],


### PR DESCRIPTION
## Summary
- The `imshow()` call drawing the FFT amplitude map on the right-hand panel in `UzeroFlagger.plotAll()` (`caracal/workers/utils/flag_Uzeros.py`) was dropped during the `ac245834` ("Fixes #1670") reformatting pass and never replaced.
- Since then the right panel only ever draws an optional red contour (gated on `ctff` being truthy) — with no `ctff`, or even with one, no image data is ever plotted, so the panel shows axes/labels on an otherwise blank white background.
- This restores the `imshow()` call ahead of the existing (still conditional) contour overlay, matching the pre-`ac245834` behaviour.

## Test plan
- [ ] Re-run `flag_u_zeros` on a dataset that previously produced blank right-hand FFT panels and confirm the panel now shows the FFT amplitude image.
- [ ] Confirm the optional red contour still overlays correctly when a `ctff` cutoff is set.