### PR TITLE
Pin ruff, select rules explicitly, and adopt phase 1 (B, UP)

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -20,10 +20,26 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: astral-sh/ruff-action@v3
+    # Pin ruff. Its default rule set is not stable across releases (0.16.0 went
+    # from 59 to 413 default rules), so an unpinned action turns green branches
+    # red with no config change. Bump this and pyproject together, deliberately.
     - uses: astral-sh/ruff-action@v3
       with:
+        version: "0.16.6"
+    - uses: astral-sh/ruff-action@v3
+      with:
+        version: "0.16.6"
         args: "format --check --diff"
+    # Buffer phase: the next tier of rules, advisory only. This never fails the
+    # build -- it is here so the team can see what Phase 1 will ask for before
+    # it becomes blocking. Promote these into ruff.toml's `select` once the
+    # backlog is cleared -- as Phase 1 (B, UP) already was.
+    - name: Lint (next phase, advisory)
+      continue-on-error: true
+      uses: astral-sh/ruff-action@v3
+      with:
+        version: "0.16.6"
+        args: "check --extend-select C4,SIM --ignore SIM108 --statistics"
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -16,7 +16,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        # Keep in step with requires-python in pyproject.toml (>=3.9,<3.13).
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4
@@ -30,16 +31,18 @@ jobs:
       with:
         version: "0.16.6"
         args: "format --check --diff"
-    # Buffer phase: the next tier of rules, advisory only. This never fails the
-    # build -- it is here so the team can see what Phase 1 will ask for before
+    # Buffer phase: phase 2 (C4, SIM), advisory only. This never fails the build
+    # -- it is here so the team can see what the next tier will ask for before
     # it becomes blocking. Promote these into ruff.toml's `select` once the
-    # backlog is cleared -- as Phase 1 (B, UP) already was.
-    - name: Lint (next phase, advisory)
+    # backlog is cleared, as phase 1 (B, UP) already was.
+    # `--output-format concise` is required: the action exports
+    # RUFF_OUTPUT_FORMAT=github, which --statistics rejects with exit code 2.
+    - name: Lint (phase 2, advisory)
       continue-on-error: true
       uses: astral-sh/ruff-action@v3
       with:
         version: "0.16.6"
-        args: "check --extend-select C4,SIM --ignore SIM108 --statistics"
+        args: "check --extend-select C4,SIM --ignore SIM108 --output-format concise"
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
@@ -49,6 +52,6 @@ jobs:
       with:
         version: "0.10.8"
     - name: Install package
-      run: uv sync --group tests --group dev
+      run: uv sync --python ${{ matrix.python-version }} --group tests --group dev
     - name: Test with pytest
       run: uv run pytest tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.12.9
+    rev: v0.16.6
     hooks:
       # Run the linter.
       - id: ruff-check

--- a/caracal/dispatch_crew/config_parser.py
+++ b/caracal/dispatch_crew/config_parser.py
@@ -133,7 +133,7 @@ class config_parser:
         try:
             config_content = utils.load_yaml(config_file)
         except BaseException as exc:  # noqa: BLE001
-            raise ConfigErrors(config_file, {"at top level": [str(exc)]})
+            raise ConfigErrors(config_file, {"at top level": [str(exc)]}) from exc
 
         version = None
         # Validate each worker section against the schema and

--- a/caracal/dispatch_crew/utils.py
+++ b/caracal/dispatch_crew/utils.py
@@ -341,7 +341,7 @@ def read_taylor_legodi_row(info, field):
 
     file_path = caracal.pckgdir + "/data/taylor_legodi_2024.txt"
 
-    with open(file_path, mode="r", encoding="utf-8") as file:
+    with open(file_path, encoding="utf-8") as file:
         lines = file.readlines()
 
         if not lines:

--- a/caracal/notebooks/__init__.py
+++ b/caracal/notebooks/__init__.py
@@ -44,7 +44,7 @@ def setup_default_notebooks(notebooks, output_dir, prefix, config):
                 template = _j2env.get_template(nbfile + ".j2")
                 log.info(f"Creating standard notebook {nbdest} from template")
 
-                with open(nbdest, "wt") as file:
+                with open(nbdest, "w") as file:
                     try:
                         print(template.render(**config), file=file)
                     except jinja2.TemplateError as exc:

--- a/caracal/workers/flag_worker.py
+++ b/caracal/workers/flag_worker.py
@@ -238,7 +238,7 @@ def worker(pipeline, recipe, config):
                 if config["flag_shadow"]["full_mk64"]:
                     addantennafile = f"{pipeline.input:s}/mk64.txt"
                     subarray = msdict["ANT"]["NAME"]
-                    idleants = open(addantennafile, "r").readlines()  # noqa: SIM115
+                    idleants = open(addantennafile).readlines()  # noqa: SIM115
                     for aa in subarray:
                         for kk in range(len(idleants)):
                             if aa in idleants[kk]:

--- a/caracal/workers/line_worker.py
+++ b/caracal/workers/line_worker.py
@@ -301,7 +301,7 @@ def worker(pipeline, recipe, config):
 
         for i, msfile in enumerate(all_msfiles):
             msinfo = f"{pipeline.msdir:s}/{os.path.splitext(msfile)[0]:s}-obsinfo.txt"
-            with open(msinfo, "r") as searchfile:
+            with open(msinfo) as searchfile:
                 for longdatexp in searchfile:
                     if "Observed from" in longdatexp:
                         dates = longdatexp
@@ -1876,7 +1876,7 @@ def worker(pipeline, recipe, config):
                                 # if cube in m/s then convert the velocity_range in km/s
                                 vel_range = vel_range / 1e3
 
-                        for item in config["imcontsub"]["segments"]:
+                        for _item in config["imcontsub"]["segments"]:
                             if vel_range < config["imcontsub"]["segments"]:
                                 caracal.log.warning("The width of the spline is larger than the spectral width of the cube, please check your segments keyword")
 
@@ -1932,7 +1932,7 @@ def worker(pipeline, recipe, config):
                             if "km" in hdul_cube["cdelt3"].lower():
                                 # if cube in m/s then convert the velocity_range in km/s
                                 vel_range = vel_range / 1e3
-                        for item in config["imcontsub"]["segments"]:
+                        for _item in config["imcontsub"]["segments"]:
                             if vel_range < config["imcontsub"]["segments"]:
                                 caracal.log.warning("The width of the spline is larger than the spectral width of the cube, please check your segments keyword")
 

--- a/caracal/workers/obsconf_worker.py
+++ b/caracal/workers/obsconf_worker.py
@@ -148,7 +148,7 @@ def worker(pipeline, recipe, config):
         # get the  actual date stamp for the start and end of the observations.
         # !!!!!!! This info appears to not be present in the json file just the
         #  totals and start times (without slew times) so we'll get it from the txt file
-        with open(os.path.join(pipeline.msdir, obsinfo), "r") as stdr:
+        with open(os.path.join(pipeline.msdir, obsinfo)) as stdr:
             content = stdr.readlines()
         for line in content:
             info_on_line = [x for x in line.split() if x != ""]

--- a/caracal/workers/polcal_worker.py
+++ b/caracal/workers/polcal_worker.py
@@ -893,7 +893,7 @@ with open(outfile, 'w') as json_file:
         recipe.run()
         recipe.jobs = []
 
-        with open(os.path.join(pipeline.caltables, prefix) + "_bestscan.json", "r") as json_file:
+        with open(os.path.join(pipeline.caltables, prefix) + "_bestscan.json") as json_file:
             data = json.load(json_file)
             bestscan = data["bestscan"]
 
@@ -1422,7 +1422,7 @@ def worker(pipeline, recipe, config):
                 caracal.log.info("Setting model pol")
                 if config["set_model_pol"]["nrao_model"]:
                     file_path = caracal.pckgdir + "/data/nrao_xcal.yml"
-                    polarized_calibrators = yaml.safe_load(open(file_path, "r", encoding="utf-8"))  # noqa: SIM115
+                    polarized_calibrators = yaml.safe_load(open(file_path, encoding="utf-8"))  # noqa: SIM115
                     polarized_calibrators["J1331+3030"] = polarized_calibrators["3C286"]
                     polarized_calibrators["J0521+1638"] = polarized_calibrators["3C138"]
                 elif config["set_model_pol"]["taylor_legodi_model"]:

--- a/caracal/workers/selfcal_worker.py
+++ b/caracal/workers/selfcal_worker.py
@@ -109,7 +109,7 @@ def check_config(config, name):
                 amount_sols = len(config["calibrate"]["gasols_timeslots"])
             else:
                 amount_sols = int(config["cal_niter"])
-            for i, val in enumerate(config["calibrate"]["gasols_timeslots"][:amount_sols]):
+            for val in config["calibrate"]["gasols_timeslots"][:amount_sols]:
                 if val >= 0:
                     solutions.append(val)
         # then we assign the timechunk
@@ -158,7 +158,7 @@ def check_config(config, name):
                     amount_sols = len(config["calibrate"]["gasols_chan"])
                 else:
                     amount_sols = int(config["cal_niter"])
-                for i, val in enumerate(config["calibrate"]["gasols_chan"][:amount_sols]):
+                for val in config["calibrate"]["gasols_chan"][:amount_sols]:
                     if val >= 0:
                         solutions.append(val)
             # then we assign the timechunk
@@ -1489,7 +1489,7 @@ def worker(pipeline, recipe, config):
             sol_terms_add.append(str(solterm_niter[SOL_TERMS_INDEX[term]]))
         flags = "-cubical"
 
-        for i, msname in enumerate(mslist):
+        for msname in mslist:
             # Due to a bug in cubical full polarization datasets are not compliant with sel-diag: True
             # Hence this temporary fix.
             corrs = pipeline.get_msinfo(msname)["CORR"]["CORR_TYPE"]

--- a/caracal/workers/worker_administrator.py
+++ b/caracal/workers/worker_administrator.py
@@ -112,12 +112,12 @@ class WorkerAdministrator:
 
         # Get possible flagsets for reduction
         self.flags = {"legacy": ["legacy"]}
-        for _name, _worker, i in self.workers:
+        for _name, _worker, _i in self.workers:
             try:
                 wkr = __import__(_worker)
             except ImportError:
                 traceback.print_exc()
-                raise ImportError(f'Worker "{_worker:s}" could not be found at {self.workers_directory:s}')
+                raise ImportError(f'Worker "{_worker:s}" could not be found at {self.workers_directory:s}') from None
 
             if hasattr(wkr, "FLAG_NAMES"):
                 self.flags[_name] = ["_".join([_name, suffix]) if suffix else _name for suffix in wkr.FLAG_NAMES]  # noqa: FLY002
@@ -375,12 +375,12 @@ class WorkerAdministrator:
         """Runs the  workers"""
         report_updated = False
 
-        for _name, _worker, i in self.workers:
+        for _name, _worker, _i in self.workers:
             try:
                 worker = __import__(_worker)
             except ImportError:
                 traceback.print_exc()
-                raise ImportError(f'Worker "{_worker:s}" could not be found at {self.workers_directory:s}')
+                raise ImportError(f'Worker "{_worker:s}" could not be found at {self.workers_directory:s}') from None
 
         if self.config["general"]["cabs"]:
             log.info("Configuring cab specification overrides")
@@ -389,7 +389,7 @@ class WorkerAdministrator:
             cabspecs_general = {}
         active_workers = []
         # first, check that workers import, and check their configs
-        for _name, _worker, i in self.workers:
+        for _name, _worker, _i in self.workers:
             config = self.config[_name]
             if "enable" in config and not config["enable"]:
                 self.skip.append(_worker)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,13 +48,13 @@ caracal = "caracal.main:driver"
 [dependency-groups]
 dev = [
     "jupyter",
-    "ruff>=0.12.9",
+    "ruff==0.16.6",
     "pre-commit>=4.3.0",
 ]
 tests = [
     "pytest>=7.1.3,<8",
     "flake8>=5.0.0,<6",
-    "ruff>=0.12.9",
+    "ruff==0.16.6",
 ]
 docs = [
     "Sphinx>=4.0.1,<5",

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,15 +1,40 @@
 line-length = 180
-target-version = "py310"
+target-version = "py39"  # must not exceed pyproject requires-python (>=3.9)
+
+# Ruff's *default* rule selection is not stable across releases: 0.16.0 widened
+# it from 59 rules to 413. Because CI installs the latest ruff, that silently
+# turned green branches red without anyone touching this file. So: select
+# explicitly, pin the ruff version (pyproject + python-ci.yml), and widen the
+# set deliberately, one tier at a time.
+#
+# Ramp plan (see docs/ or the linting issue for the schedule):
+#   Phase 0  (done)  E4,E7,E9,E501,F,I
+#   Phase 1  (done)  + "B", "UP"                   -- 18 violations cleared
+#   Phase 2  (next)  + "C4", "SIM" (minus SIM108)  -- 6 violations to clear
+# SIM108 (if-else -> ternary) stays excluded for good: 78 hits, all of them
+# rewriting readable blocks into ternaries. Not worth it.
+# The next phase runs advisory-only in CI (continue-on-error) so the team can
+# see what is coming without being blocked by it.
+
+[format]
+# The tree was formatted with the preview formatter; keep it so dropping
+# preview from the *linter* does not churn 6 unrelated files.
 preview = true
 
 [lint]
-extend-select = [
-    "E501",  # Line length
-    "I"      # isort - sort imports
+preview = false
+select = [
+    "E4",    # pycodestyle: imports
+    "E7",    # pycodestyle: statement-level mistakes
+    "E9",    # pycodestyle: syntax / IO errors
+    "E501",  # line too long (at 180, so only egregious cases)
+    "F",     # pyflakes: undefined names, unused imports -- real bugs
+    "I",     # isort: import ordering
+    "B",     # flake8-bugbear: likely bugs (unused loop vars, bad except chains)
+    "UP",    # pyupgrade: keep syntax current with target-version
 ]
 
 ignore = [
-"E741",
-"E714",
-"E711",
+    "E741",  # ambiguous name `l`/`I` -- `I` is intensity in radio astronomy
+    "E714",  # `not x is None` -- 3 sites left; fix them, then drop this ignore
 ]


### PR DESCRIPTION
## Why

CI installs ruff through `ruff-action@v3`, which takes the **latest** release, and `pyproject.toml` only asked for `ruff>=0.12.9`. Ruff 0.16.0 widened its *default* rule selection from 59 rules to 413; with `preview = true` on top, that came to 496.

| ruff version | rules enabled by default |
|---|---|
| 0.12.9 → 0.15.20 | 59 |
| **0.16.0+** | **413** |

So green branches went red with nobody editing a config file, and the failures landed on contributors in code they had never gone near. #1701 is a 7-line fix to `flag_Uzeros.py` failing on 41 errors in `line_worker.py`, `selfcal_worker.py` and `polcal_worker.py`. A checkout with ruff 0.15.20 still reports `All checks passed!` on the exact tree CI rejects — that gap is the whole bug.

This fixes the drift, then widens the ruleset on a schedule we control rather than one Astral picks for us.

## Stop the drift

- Pin `ruff==0.16.6` in `pyproject.toml` (dev + tests), `.pre-commit-config.yaml`, and both `ruff-action` steps. Bump deliberately, all four together.
- Select rules explicitly in `ruff.toml`, so a ruff upgrade can never widen scope on its own.
- Split `preview`: keep it for the **formatter** (the tree is formatted with the preview formatter — dropping it reformats 6 unrelated files) and turn it off for the **linter**.
- `target-version` was `py310` while `requires-python` is `>=3.9`; corrected to `py39`. Commits 8a5341d2 / b88be97d, adding `from __future__ import annotations` for `|` unions, look like that mismatch already biting once.
- Dropped `E711` from `ignore` — 0 hits, so it is free coverage. `E741` keeps a note that `I` is *intensity*, not a badly named variable.

## Phase 1: `B` + `UP` now blocking, all 18 violations cleared

- **7 × UP015** — semantic no-ops: `"r"` is `open()`'s default, `"wt"` ≡ `"w"`.
- **8 × B007** — unused loop variables. Where the index came from `enumerate()` and was never read, the `enumerate()` is dropped rather than the variable renamed. In `worker_administrator.py` the unused item is the third element of a `(name, worker, i)` unpack, so it becomes `_i`, matching the `_name`/`_worker` convention already in that file.
- **3 × B904** — `config_parser.py` chains `from exc`, since the message already embeds `str(exc)`. The two in `worker_administrator.py` use `from None`: both sit directly under an explicit `traceback.print_exc()` that would otherwise report the same traceback twice.

Semantics are unchanged throughout.

## The buffer phase

CI gains a third lint step, `continue-on-error: true`, running the *next* tier advisory-only. It reports on every PR and never fails the build, so the team can see what is coming and clear it at their own pace instead of being ambushed by it.

It now previews **phase 2** (`C4`, `SIM`), down to 6 violations. `SIM108` is excluded permanently, with the reason recorded in `ruff.toml`: 78 hits, all of them rewriting readable `if`/`else` blocks into ternaries. That is the rule most likely to sour people on the linter and it buys nothing.

## Left alone on purpose

`line_worker.py:1879` and `:1935` got the minimal fix (`item` → `_item`), but the loop underneath looks wrong independently of lint: it iterates `config["imcontsub"]["segments"]` while the body compares `vel_range < config["imcontsub"]["segments"]`, i.e. a float against the whole list, which raises `TypeError` as soon as that branch runs with a non-empty list. The commented-out line just below suggests the comparison was meant to be against `item`. I have not touched the semantics — guessing at imcontsub intent inside a lint PR is how you get another ac245834, which is what #1701 is currently cleaning up. Worth a separate issue for whoever owns that code.

`E714` stays in `ignore` with a TODO: 3 sites, trivially fixable, but unrelated to the ramp.

## Test plan

- [x] `ruff check` and `ruff format --check` clean under the pinned 0.16.6
- [x] `pytest tests` — 4 passed
- [x] every edited file byte-compiles
- [x] pre-commit hooks pass on the new pin
- [ ] after merge, #1701 rebases and goes green without touching `flag_Uzeros.py`